### PR TITLE
🐛 150 - Send error for dup publication urls. do not remove dup urls

### DIFF
--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -127,8 +127,9 @@ export class ApplicationStateManager {
     }
 
     // calculate the value of revisions requested field for the FE to use it.
-    this.currentApplication.revisionsRequested = this.currentApplication.state == 'REVISIONS REQUESTED'
-      || wasInRevisionRequestState(this.currentApplication);
+    this.currentApplication.revisionsRequested =
+      this.currentApplication.state == 'REVISIONS REQUESTED' ||
+      wasInRevisionRequestState(this.currentApplication);
 
     return this.currentApplication;
   }
@@ -889,11 +890,6 @@ function updateProjectInfo(updatePart: Partial<UpdateApplication>, current: Appl
       current.sections.projectInfo,
       updatePart.sections.projectInfo,
     );
-    // remove duplicated /  falsy values
-    const uniquePubs = _.uniq(
-      current.sections.projectInfo.publicationsURLs.filter((v) => !!v?.trim()),
-    );
-    current.sections.projectInfo.publicationsURLs = uniquePubs;
     validateProjectInfo(current);
   }
 }

--- a/src/domain/validations.ts
+++ b/src/domain/validations.ts
@@ -9,7 +9,7 @@ import {
   SectionStatus,
 } from './interface';
 import validator from 'validate.js';
-import _ from 'lodash';
+import _, { uniq } from 'lodash';
 import { countriesList } from '../utils/constants';
 import { c } from '../utils/misc';
 
@@ -197,7 +197,15 @@ function validatePublications(publications: string[], errors: SectionError[]) {
     });
     return false;
   }
-
+  const hasDuplicatePubs =
+    uniq(publications.filter((v) => !!v?.trim())).length < publications.length;
+  if (hasDuplicatePubs) {
+    errors.push({
+      field: 'publications',
+      message: 'Publication URLS must be unique',
+    });
+    return false;
+  }
   const validations = publications.map((p: string, index: number) => {
     return validateUrl(p, `publications.${index}`, errors);
   });


### PR DESCRIPTION
When duplicate publication urls are added, API will respond with an error instead of removing the duplicate strings.