### PR TITLE
#163 - uploading ethics letter with same name as already uploaded

### DIFF
--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -621,17 +621,21 @@ function uploadEthicsLetter(current: Application, id: string, name: string, upda
   if (!current.sections.ethicsLetter.declaredAsRequired) {
     throw new Error('Must declare ethics letter as required first');
   }
+
   const updatePart: Partial<UpdateApplication> = {
     sections: {
       ethicsLetter: {
         // we need to provide the existing items as well for the merge logic to work correctly and not delete array items
-        approvalLetterDocs: current.sections.ethicsLetter.approvalLetterDocs.concat([
-          {
-            name,
-            objectId: id,
-            uploadedAtUtc: new Date(),
-          },
-        ]),
+        approvalLetterDocs: current.sections.ethicsLetter.approvalLetterDocs
+          // remove any current docs that have new docs name
+          .filter((doc) => doc.name !== name)
+          .concat([
+            {
+              name,
+              objectId: id,
+              uploadedAtUtc: new Date(),
+            },
+          ]),
       },
     },
   };


### PR DESCRIPTION
ethics approval docs can't have same name
ensure the latest upload with same name is only one saved
user is prompted for confirmation of this operation on frontend