### PR TITLE
✨ 225 - Allow multiple approved pdfs to be attached to an app

### DIFF
--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -122,6 +122,15 @@ export type SectionError = {
   message: string;
   code?: string;
 };
+
+type ApprovedAppDocument = {
+  approvedAppDocObjId: string;
+  uploadedAtUtc?: Date;
+  approvedAppDocName: string;
+  isCurrent: boolean;
+  approvedAtUtc: Date;
+};
+
 export interface Application {
   appId: string;
   appNumber: number;
@@ -206,11 +215,7 @@ export interface Application {
   // this is intended for human auditing and wouldn't recommend using this for any application logic
   // unless it's revised to fit the case.
   updates: ApplicationUpdate[];
-  approvedAppDoc: {
-    approvedAppDocObjId: string;
-    uploadedAtUtc?: Date;
-    approvedAppDocName: string;
-  };
+  approvedAppDocs: ApprovedAppDocument[];
 }
 
 export type AppSections = keyof Application['sections'];

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -91,6 +91,8 @@ const ApprovedAppDocument = new mongoose.Schema(
     approvedAppDocObjId: { type: String, required: false },
     uploadedAtUtc: { type: Date, required: false },
     approvedAppDocName: { type: String, required: false },
+    isCurrent: { type: Boolean, required: false },
+    approvedAtUtc: { type: Date, required: false },
   },
   { _id: false },
 );
@@ -169,7 +171,7 @@ const ApplicationSchema = new mongoose.Schema(
       },
     },
     updates: [ApplicationUpdate],
-    approvedAppDoc: { type: ApprovedAppDocument, required: false },
+    approvedAppDocs: [ApprovedAppDocument],
   },
   {
     timestamps: {


### PR DESCRIPTION
Uploading an approved pdf will still overwrite a doc marked as `isCurrent` if the doc's approval date matches the app-level approvedAtUtc.
Allows for multiple approved pdfs to be stored, but only one will be marked as current and be available to the ui for download.