### PR TITLE
🐛 281 - allow upload when signature only has revisions requested

### DIFF
--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -765,7 +765,15 @@ function transitionToRevisionsRequested(
 
   // empty the signature (need to delete the document too.)
   resetSignedDocument(current);
-  current.state = 'REVISIONS REQUESTED';
+
+  const sectionsWithRevisions = Object.keys(current.revisionRequest).filter(
+    (section) => current.revisionRequest[section as keyof RevisionRequestUpdate].requested,
+  );
+  const revisionsOnSignatureSectionOnly =
+    sectionsWithRevisions.length === 1 && sectionsWithRevisions[0] === 'signature';
+
+  // put into SIGN AND SUBMIT state when just the signature section has revisions requested to allow user to upload a new signed doc
+  current.state = revisionsOnSignatureSectionOnly ? 'SIGN AND SUBMIT' : 'REVISIONS REQUESTED';
   current.updates.push(createUpdateEvent(current, updateAuthor, UpdateEvent.REVISIONS_REQUESTED));
   return current;
 }

--- a/src/test/state.spec.ts
+++ b/src/test/state.spec.ts
@@ -332,6 +332,52 @@ describe('state manager', () => {
     const userApp = state.prepareApplicationForUser(false);
     expect(userApp.sections.representative.meta.status).to.eq('REVISIONS REQUESTED');
   });
+
+  it('should change to sign and submit when revisions requested on signature section only', () => {
+    const app: Application = getAppInReview();
+    const state = new ApplicationStateManager(app);
+    const updated = state.updateApp(
+      {
+        state: 'REVISIONS REQUESTED',
+        revisionRequest: {
+          applicant: {
+            requested: false,
+            details: '',
+          },
+          representative: {
+            requested: false,
+            details: '',
+          },
+          projectInfo: {
+            requested: false,
+            details: '',
+          },
+          collaborators: {
+            requested: false,
+            details: '',
+          },
+          ethicsLetter: {
+            requested: false,
+            details: '',
+          },
+          signature: {
+            requested: true,
+            details: 'signature needs to be signed',
+          },
+          general: {
+            requested: false,
+            details: '',
+          },
+        },
+      },
+      true,
+      { id: '1', role: DacoRole.ADMIN },
+    );
+
+    const userApp = state.prepareApplicationForUser(false);
+    expect(userApp.sections.signature.meta.status).to.eq('REVISIONS REQUESTED');
+    expect(userApp.state).to.eq('SIGN AND SUBMIT');
+  });
 });
 
 export function getReadyToSignApp() {


### PR DESCRIPTION
fixes bug where app can get stuck in `REVISIONS REQUESTED` state when only signature section is selected for revisions
adds test