### PR TITLE
🐛 Fix encoding to allow openssl decryption on command line

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -161,7 +161,7 @@ const buildAppContext = async (secrets: any): Promise<AppConfig> => {
       dacoAddress: process.env.EMAIL_DACO_ADDRESS || 'daco@icgc-argo.org',
       fromName: process.env.EMAIL_FROM_NAME || 'ICGC DACO',
       fromAddress: process.env.EMAIL_FROM_ADDRESS || 'no-reply-daco@icgc-argo.org',
-      dccMailingList: secrets.DCC_MAILING_LIST || process.env.DCC_MAILING_LIST,
+      dccMailingList: process.env.DCC_MAILING_LIST || '',
       auth: {
         user: secrets.EMAIL_USER || process.env.EMAIL_USER,
         password: secrets.EMAIL_PASSWORD || process.env.EMAIL_PASSWORD,

--- a/src/routes/applications.ts
+++ b/src/routes/applications.ts
@@ -106,9 +106,9 @@ const createApplicationsRouter = (
         logger.error(`Error downloading zip file for ${appId}: ${error}`);
         // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#unknown-on-catch-clause-bindings
         if (error instanceof Error) {
-          return res.status(400).send(error.message);
+          return res.status(500).send(error.message);
         }
-        return res.status(400).send('An unknown error occurred.');
+        return res.status(500).send('An unknown error occurred.');
       }
     }),
   );
@@ -266,12 +266,12 @@ const createApplicationsRouter = (
           config.email.fromName,
           new Set([config.email.dccMailingList]),
           'Approved DACO Users', // TODO: verify expected subject line
-          `${encrypted?.iv}`,
+          `${encrypted.iv}`,
           undefined,
           [
             {
               filename: 'approved_users.csv',
-              content: encrypted?.content,
+              content: encrypted.content,
               contentType: 'text/plain',
             },
           ],
@@ -281,7 +281,7 @@ const createApplicationsRouter = (
         if (err instanceof Error) {
           return res.status(500).send(err.message);
         }
-        res.status(400).send('An unknown error occurred.');
+        res.status(500).send('An unknown error occurred.');
       }
     }),
   );

--- a/src/test/encryption.spec.ts
+++ b/src/test/encryption.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import { createDecipheriv } from 'crypto';
 import { encrypt } from '../utils/misc';
-import { CHAR_ENCODING, DACO_ENCRYPTION_ALGO, EMAIL_CONTENT_ENCODING } from '../utils/constants';
+import {
+  EMAIL_ENCRYPTION_CREDENTIALS_ENCODING,
+  DACO_ENCRYPTION_ALGO,
+  EMAIL_CONTENT_ENCODING,
+} from '../utils/constants';
 
 describe('encryption', () => {
   it('should encrypt and decrypt text', async () => {
@@ -31,8 +35,8 @@ describe('encryption', () => {
 
       const decipher = createDecipheriv(
         DACO_ENCRYPTION_ALGO,
-        Buffer.from(mockEncryptionKey, CHAR_ENCODING),
-        Buffer.from(encrypted!.iv, CHAR_ENCODING),
+        Buffer.from(mockEncryptionKey, EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
+        Buffer.from(encrypted!.iv, EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
       );
       const decrypted = Buffer.concat([
         decipher.update(Buffer.from(encrypted!.content, EMAIL_CONTENT_ENCODING)),

--- a/src/test/encryption.spec.ts
+++ b/src/test/encryption.spec.ts
@@ -26,8 +26,8 @@ describe('encryption', () => {
       expect(encrypted).to.not.be.empty;
       expect(encrypted).to.haveOwnProperty('iv');
       expect(encrypted).to.haveOwnProperty('content');
-      expect(typeof encrypted?.iv).to.eq('string');
-      expect(typeof encrypted?.content).to.eq('string');
+      expect(typeof encrypted.iv).to.eq('string');
+      expect(typeof encrypted.content).to.eq('string');
 
       // command to decrypt encrypted.content with openssl in command line:
       // openssl enc -aes-128-cbc -d -a -K <key> -iv <iv> -in <input file> -out <output file>
@@ -36,10 +36,10 @@ describe('encryption', () => {
       const decipher = createDecipheriv(
         DACO_ENCRYPTION_ALGO,
         Buffer.from(mockEncryptionKey, EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
-        Buffer.from(encrypted!.iv, EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
+        Buffer.from(encrypted.iv, EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
       );
       const decrypted = Buffer.concat([
-        decipher.update(Buffer.from(encrypted!.content, EMAIL_CONTENT_ENCODING)),
+        decipher.update(Buffer.from(encrypted.content, EMAIL_CONTENT_ENCODING)),
         decipher.final(),
       ]);
       expect(decrypted.toString()).to.eq(text);

--- a/src/test/encryption.spec.ts
+++ b/src/test/encryption.spec.ts
@@ -34,7 +34,6 @@ describe('encryption', () => {
         Buffer.from(mockEncryptionKey, CHAR_ENCODING),
         Buffer.from(encrypted!.iv, CHAR_ENCODING),
       );
-      decipher.setAutoPadding(true);
       const decrypted = Buffer.concat([
         decipher.update(Buffer.from(encrypted!.content, EMAIL_CONTENT_ENCODING)),
         decipher.final(),

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -254,7 +254,7 @@ export const countriesList: string[] = countries
 
 // encryption
 export const DACO_ENCRYPTION_ALGO = 'aes-128-cbc';
-export const CHAR_ENCODING = 'hex';
+export const EMAIL_ENCRYPTION_CREDENTIALS_ENCODING = 'hex';
 export const EMAIL_CONTENT_ENCODING = 'base64';
 export const IV_LENGTH = 16;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -252,8 +252,10 @@ export const countriesList: string[] = countries
   .map((s) => s.name)
   .sort((a, b) => a.localeCompare(b));
 
+// encryption
 export const DACO_ENCRYPTION_ALGO = 'aes-128-cbc';
-export const CHAR_ENCODING = 'latin1';
+export const CHAR_ENCODING = 'hex';
+export const EMAIL_CONTENT_ENCODING = 'base64';
 export const IV_LENGTH = 16;
 
 // URLS

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -13,7 +13,7 @@ import { search, SearchParams } from '../domain/service';
 import { IRequest } from '../routes/applications';
 import { createCipheriv, randomBytes } from 'crypto';
 import {
-  CHAR_ENCODING,
+  EMAIL_ENCRYPTION_CREDENTIALS_ENCODING,
   DACO_ENCRYPTION_ALGO,
   EMAIL_CONTENT_ENCODING,
   IV_LENGTH,
@@ -142,7 +142,7 @@ export const encrypt: (
     const iv = randomBytes(IV_LENGTH);
     const cipher = createCipheriv(
       DACO_ENCRYPTION_ALGO,
-      Buffer.from(encryptionKey, CHAR_ENCODING),
+      Buffer.from(encryptionKey, EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
       iv,
     );
     const encrypted = Buffer.concat([cipher.update(text), cipher.final()]);
@@ -150,11 +150,12 @@ export const encrypt: (
     // https://wiki.openssl.org/index.php/Command_Line_Utilities#Base64_Encoding_Strings
     const encodedContent = encrypted.toString(EMAIL_CONTENT_ENCODING).replace(/(.{64})/g, '$1\n');
     return {
-      iv: iv.toString(CHAR_ENCODING),
+      iv: iv.toString(EMAIL_ENCRYPTION_CREDENTIALS_ENCODING),
       content: encodedContent,
     };
   } catch (err) {
-    console.warn('Encryption failure: ', err);
+    console.error('Encryption failure: ', err);
+    throw new Error('Encryption failure');
   }
 };
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -136,7 +136,7 @@ export const createDacoCSVFile = async (req: Request) => {
 export const encrypt: (
   text: string,
   encryptionKey: string,
-) => Promise<{ iv: string; content: string } | undefined> = async (text, encryptionKey) => {
+) => Promise<{ iv: string; content: string }> = async (text, encryptionKey) => {
   try {
     // create IV as a Buffer
     const iv = randomBytes(IV_LENGTH);

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -145,8 +145,6 @@ export const encrypt: (
       Buffer.from(encryptionKey, CHAR_ENCODING),
       iv,
     );
-    // default is no padding, set this so -nopad flag isn't needed in openssl command
-    cipher.setAutoPadding(true);
     const encrypted = Buffer.concat([cipher.update(text), cipher.final()]);
     // split into 64-character lines, so -A is not needed in openssl command, apparently can be buggy with longer files
     // https://wiki.openssl.org/index.php/Command_Line_Utilities#Base64_Encoding_Strings


### PR DESCRIPTION
Necessary for #95 
Needed to output encrypted content as base64 to allow decryption with `openssl` command
Fixes encryption key format
Fixes encryption key arg in cipher creation
Adds `openssl` command example to test for reference
Splits encrypted content string into 64-char lines to avoid 🐛iness in `openssl -A`
Remove secrets reference for `DCC_MAILING_LIST` var, will be added in helm values