### PR TITLE
Add config to state manager class. use configurable attestation vals

### DIFF
--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -45,6 +45,7 @@ import {
   validateRepresentativeSection,
 } from './validations';
 import { BadRequest, ConflictError, NotFound } from '../utils/errors';
+import { AppConfig } from '../config';
 
 const allSections: Array<keyof Application['sections']> = [
   'appendices',
@@ -121,9 +122,11 @@ const stateToLockedSectionsMap: Record<
 
 export class ApplicationStateManager {
   public readonly currentApplication: Application;
+  public readonly currentAppConfig: AppConfig;
 
-  constructor(application: Application) {
+  constructor(application: Application, config: AppConfig) {
     this.currentApplication = cloneDeep(application);
+    this.currentAppConfig = cloneDeep(config);
   }
 
   prepareApplicationForUser(isReviewer: boolean) {
@@ -157,6 +160,7 @@ export class ApplicationStateManager {
     if (this.currentApplication.approvedAtUtc) {
       this.currentApplication.attestationByUtc = getAttestationByDate(
         this.currentApplication.approvedAtUtc,
+        this.currentAppConfig,
       );
     }
     return this.currentApplication;

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -8,7 +8,7 @@ import {
   DacoRole,
   UpdateAuthor,
 } from '../domain/interface';
-import moment from 'moment';
+import moment, { unitOfTime } from 'moment';
 import { hasDacoSystemScope, hasReviewScope, search, SearchParams } from '../domain/service';
 import { IRequest } from '../routes/applications';
 import { createCipheriv, randomBytes } from 'crypto';
@@ -19,6 +19,7 @@ import {
   IV_LENGTH,
 } from './constants';
 import { Identity } from '@overture-stack/ego-token-middleware';
+import { AppConfig } from '../config';
 
 export function c<T>(val: T | undefined | null): T {
   if (val === undefined || val === null) {
@@ -179,5 +180,12 @@ export const sortByDate = (a: any, b: any) => {
   return b.date.getTime() - a.date.getTime();
 };
 
-export const getAttestationByDate: (approvalDate: Date) => Date = (approvalDate) =>
-  moment(approvalDate).add(1, 'year').toDate();
+export const getAttestationByDate: (approvalDate: Date, AppConfig: AppConfig) => Date = (
+  approvalDate,
+  config,
+) => {
+  const { unitOfTime, count } = config.durations?.attestation;
+  return moment(approvalDate)
+    .add(count as number, unitOfTime as unitOfTime.DurationConstructor)
+    .toDate();
+};


### PR DESCRIPTION
Adds app config to state manager constructor to avoid extra async calls for some helper functions
Updates `getAttestationByDate` to use configured attestation period
Updates tests with mock config