### PR TITLE
fix pauseable app date filter

### DIFF
--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -124,6 +124,7 @@ const ApplicationSchema = new mongoose.Schema(
     isRenewal: { type: Boolean, required: true },
     ableToRenew: { type: Boolean, required: true },
     attestedAtUtc: { type: Date, required: false },
+    pauseReason: { type: String, required: false },
     revisionRequest: {
       applicant: RevisionRequest,
       representative: RevisionRequest,

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -593,12 +593,12 @@ const getPauseableQuery = (config: AppConfig, currentDate: Date) => {
     unitOfTime as unitOfTime.DurationConstructor,
   );
   const approvalDayStart = moment(approvalDate).startOf('day').toDate();
-  const approvalDayEnd = moment(approvalDate).endOf('day').toDate();
   const query: FilterQuery<ApplicationDocument> = {
     state: 'APPROVED',
     approvedAtUtc: {
-      $gte: approvalDayStart, // check for an approvedAtUtc within a 24hr period
-      $lte: approvalDayEnd,
+      // filter for any time period equal to or past attestationByUtc in case an application that should have been paused previously
+      // is caught on a subsequent job run, as it will still be APPROVED and not have an attestedAtUtc value
+      $gte: approvalDayStart,
     },
     // tslint:disable-next-line:no-null-keyword
     $or: [{ attestedAtUtc: { $exists: false } }, { attestedAtUtc: { $eq: null } }], // check the applicant has not already attested, value may be null after renewal


### PR DESCRIPTION
Filter for approved apps with attestationByUtc of today or later, to catch any pauseable apps that are missed due to a state change error
- also adds `pauseReason` to model, this was missed in a previous pr