### PR TITLE
🗃️ 292 - calculable ableToRenew field

### DIFF
--- a/migrations/20220826193604-remove_able_to_renew_field.js
+++ b/migrations/20220826193604-remove_able_to_renew_field.js
@@ -1,0 +1,7 @@
+module.exports = {
+  async up(db, client) {
+    await db.collection('applications').updateMany({}, { $unset: { ableToRenew: 1 } });
+  },
+
+  async down(db, client) {},
+};

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -166,7 +166,8 @@ export interface ApplicationSummary {
   isRenewal: boolean;
   attestationByUtc?: Date;
   attestedAtUtc?: Date | null;
-  isAttestable?: boolean;
+  isAttestable: boolean;
+  ableToRenew: boolean;
 }
 
 export type ApplicationDto = Omit<Application, 'searchField'>;
@@ -235,6 +236,7 @@ export interface Sections {
     signedDocName: string;
   };
 }
+
 export interface Application {
   appId: string;
   appNumber: number;
@@ -269,7 +271,7 @@ export interface Application {
   approvedAppDocs: ApprovedAppDocument[];
   attestationByUtc?: Date; // calculated from approvedAtUtc
   attestedAtUtc?: Date | null;
-  isAttestable?: boolean;
+  isAttestable: boolean;
   pauseReason?: string;
 }
 

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -122,7 +122,6 @@ const ApplicationSchema = new mongoose.Schema(
     denialReason: { type: String, required: false },
     searchValues: { type: [String], index: true, required: false },
     isRenewal: { type: Boolean, required: true },
-    ableToRenew: { type: Boolean, required: true },
     attestedAtUtc: { type: Date, required: false },
     pauseReason: { type: String, required: false },
     revisionRequest: {

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -50,7 +50,7 @@ import renderAttestationReceivedEmail from '../emails/attestation-received';
 
 import { Report } from '../routes/applications';
 import { c, getDacoRole, getUpdateAuthor } from '../utils/misc';
-import { getAttestationByDate, isAttestable, sortByDate } from '../utils/calculations';
+import { getAttestationByDate, isAttestable, isRenewable, sortByDate } from '../utils/calculations';
 
 type RejectedUpdate = { status: 'rejected'; reason: string };
 type FulfilledUpdate = { status: 'fulfilled'; value: Application };
@@ -520,6 +520,7 @@ export async function search(params: SearchParams, identity: Identity): Promise<
         ...(params.includeCollaborators && {
           collaborators: app.sections.collaborators.list.map((collab: Collaborator) => collab.info),
         }),
+        ableToRenew: isRenewable(app, config),
         revisionsRequested: wasInRevisionRequestState(app),
         currentApprovedAppDoc: !!app.approvedAppDocs.find((doc) => doc.isCurrent),
         ...(app.approvedAtUtc && {

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -47,7 +47,12 @@ import {
 import { BadRequest, ConflictError, NotFound } from '../utils/errors';
 import { AppConfig } from '../config';
 import { getUpdateAuthor, mergeKnown } from '../utils/misc';
-import { getAttestationByDate, getDaysElapsed, isAttestable } from '../utils/calculations';
+import {
+  getAttestationByDate,
+  getDaysElapsed,
+  isAttestable,
+  isRenewable,
+} from '../utils/calculations';
 
 const allSections: Array<keyof Application['sections']> = [
   'appendices',
@@ -167,6 +172,11 @@ export class ApplicationStateManager {
     }
     // add isAttestable so FE doesn't need to do the calculation
     this.currentApplication.isAttestable = isAttestable(
+      this.currentApplication,
+      this.currentAppConfig,
+    );
+    // calculate renewable status
+    this.currentApplication.ableToRenew = isRenewable(
       this.currentApplication,
       this.currentAppConfig,
     );

--- a/src/test/state.spec.ts
+++ b/src/test/state.spec.ts
@@ -21,6 +21,11 @@ const nonAttestableConfig = {
       unitOfTime: 'years',
       daysToAttestation: 45,
     },
+    expiry: {
+      daysToExpiry1: 90,
+      daysToExpiry2: 45,
+      daysPostExpiry: 90,
+    },
   },
 } as AppConfig;
 
@@ -30,6 +35,11 @@ const attestableConfig = {
       count: 10,
       unitOfTime: 'days',
       daysToAttestation: 45,
+    },
+    expiry: {
+      daysToExpiry1: 90,
+      daysToExpiry2: 45,
+      daysPostExpiry: 90,
     },
   },
 } as AppConfig;

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,8 +1,14 @@
 import { expect } from 'chai';
 import moment, { unitOfTime } from 'moment';
 import { AppConfig } from '../config';
-import { getDaysElapsed, isAttestable } from '../utils/calculations';
-import { getApprovedApplication, getPausedApplication } from './state.spec';
+import { getDaysElapsed, isAttestable, isRenewable } from '../utils/calculations';
+import {
+  getApprovedApplication,
+  getClosedAfterApprovalApplication,
+  getPausedApplication,
+  getReadyToSignApp,
+  getRejectedApplication,
+} from './state.spec';
 
 const mockConfig = {
   durations: {
@@ -84,6 +90,101 @@ describe('utils', () => {
       pausedApp.approvedAtUtc = mockApprovalDate;
       const canAttest = isAttestable(pausedApp, mockConfig);
       expect(canAttest).to.be.true;
+    });
+  });
+
+  describe('isRenewable', () => {
+    const mockRenewalConfig = {
+      durations: {
+        expiry: {
+          daysToExpiry1: 90,
+          daysToExpiry2: 45,
+          daysPostExpiry: 90,
+          count: 150,
+          unitOfTime: 'days',
+        },
+      },
+    } as AppConfig;
+
+    it('should not be renewable in CLOSED state', () => {
+      const closedApp = getClosedAfterApprovalApplication();
+      const canRenew = isRenewable(closedApp, mockRenewalConfig);
+      expect(canRenew).to.be.false;
+    });
+
+    it('should not be renewable in REJECTED state', () => {
+      const rejectedApp = getRejectedApplication();
+      const canRenew = isRenewable(rejectedApp, mockRenewalConfig);
+      expect(canRenew).to.be.false;
+    });
+
+    it('should be renewable if app has never been APPROVED', () => {
+      const readyToSignApp = getReadyToSignApp();
+      const canRenew = isRenewable(readyToSignApp, mockRenewalConfig);
+      expect(canRenew).to.be.false;
+    });
+
+    it('should be renewable less than 90 days past expiry', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().subtract(45, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.true;
+    });
+
+    it('should not be renewable more than 90 days past expiry', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().subtract(100, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.false;
+    });
+
+    it('should be renewable exactly 90 days past expiry', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().subtract(90, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.true;
+    });
+
+    it('should be renewable less than 90 days before expiry', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().add(75, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.true;
+    });
+
+    it('should be renewable exactly 90 days before expiry', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().add(90, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.true;
+    });
+
+    it('should not be renewable more than 90 days before expiry', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().add(120, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.false;
+    });
+
+    it('should be renewable on the day it expires', () => {
+      const app = getApprovedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc();
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app, mockRenewalConfig);
+      expect(canRenew).to.be.true;
     });
   });
 });

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -5,6 +5,7 @@ import { getDaysElapsed, isAttestable, isRenewable } from '../utils/calculations
 import {
   getApprovedApplication,
   getClosedAfterApprovalApplication,
+  getClosedBeforeApprovalApplication,
   getPausedApplication,
   getReadyToSignApp,
   getRejectedApplication,
@@ -106,8 +107,14 @@ describe('utils', () => {
       },
     } as AppConfig;
 
-    it('should not be renewable in CLOSED state', () => {
+    it('should not be renewable in CLOSED after approval state', () => {
       const closedApp = getClosedAfterApprovalApplication();
+      const canRenew = isRenewable(closedApp, mockRenewalConfig);
+      expect(canRenew).to.be.false;
+    });
+
+    it('should not be renewable in CLOSED before approval state', () => {
+      const closedApp = getClosedBeforeApprovalApplication();
       const canRenew = isRenewable(closedApp, mockRenewalConfig);
       expect(canRenew).to.be.false;
     });

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -79,6 +79,6 @@ export const isRenewable: (currentApp: Application, config: AppConfig) => boolea
     .endOf('day')
     .add(config.durations.expiry.daysPostExpiry, 'days');
 
-  // between 90 days prior to today and 90 days after
+  // between DAYS_TO_EXPIRY_1 days prior to today and DAYS_POST_EXPIRY after
   return now.isBetween(expiryPeriodStart, expiryPeriodEnd);
 };

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -46,3 +46,28 @@ export const isAttestable: (currentApp: Application, config: AppConfig) => boole
   const elapsed = getDaysElapsed(now, attestationByDate);
   return elapsed >= -config.durations.attestation.daysToAttestation;
 };
+('');
+export const isRenewable: (currentApp: Application, config: AppConfig) => boolean = (
+  currentApp,
+  config,
+) => {
+  // TODO: verify whether PAUSED apps can be renewed
+  if (!currentApp.expiresAtUtc || ['CLOSED', 'REJECTED'].includes(currentApp.state)) {
+    return false;
+  }
+  const now = moment.utc();
+  // expiry - DAYS_TO_EXPIRY_1
+  const expiryPeriodStart = moment
+    .utc(currentApp.expiresAtUtc)
+    .startOf('day')
+    .subtract(config.durations.expiry.daysToExpiry1, 'days');
+
+  // expiry + DAYS_POST_EXPIRY
+  const expiryPeriodEnd = moment
+    .utc(currentApp.expiresAtUtc)
+    .endOf('day')
+    .add(config.durations.expiry.daysPostExpiry, 'days');
+
+  // between 90 days prior to today and 90 days after
+  return now.isBetween(expiryPeriodStart, expiryPeriodEnd);
+};

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -51,8 +51,10 @@ export const isRenewable: (currentApp: Application, config: AppConfig) => boolea
   currentApp,
   config,
 ) => {
+  // if the user has already started the renewal process, app state will be in DRAFT, SIGN AND SUBMIT, REVIEW or REVISIONS REQUESTED,
+  // so need to look for apps still in APPROVED or EXPIRED state, which means no action has been taken yet
   // TODO: verify whether PAUSED apps can be renewed
-  if (!currentApp.expiresAtUtc || ['CLOSED', 'REJECTED'].includes(currentApp.state)) {
+  if (!(currentApp.expiresAtUtc && ['APPROVED', 'EXPIRED'].includes(currentApp.state))) {
     return false;
   }
   const now = moment.utc();


### PR DESCRIPTION
change `ableToRenew` to calculated field
- migration to remove this field from the db
- add the field to `Application` and `ApplicationSummary` response
- create util function to calculate renewable status
- add tests