### PR TITLE
✨ 340 - add lastPausedAtUtc to app and summary responses

### DIFF
--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -275,7 +275,7 @@ export interface Application {
   approvedAppDocs: ApprovedAppDocument[];
   attestationByUtc?: Date; // calculated from approvedAtUtc
   attestedAtUtc?: Date | null;
-  isAttestable?: boolean;
+  isAttestable: boolean;
   pauseReason?: PauseReason | null;
   lastPausedAtUtc?: Date;
 }

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -171,7 +171,8 @@ export interface ApplicationSummary {
   isRenewal: boolean;
   attestationByUtc?: Date;
   attestedAtUtc?: Date | null;
-  isAttestable?: boolean;
+  isAttestable: boolean;
+  lastPausedAtUtc?: Date;
 }
 
 export type ApplicationDto = Omit<Application, 'searchField'>;
@@ -276,6 +277,7 @@ export interface Application {
   attestedAtUtc?: Date | null;
   isAttestable?: boolean;
   pauseReason?: PauseReason | null;
+  lastPausedAtUtc?: Date;
 }
 
 export type AppSections = keyof Application['sections'];

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -48,7 +48,7 @@ import renderAttestationRequiredEmail from '../emails/attestation-required';
 import renderApplicationPausedEmail from '../emails/application-paused';
 import renderAttestationReceivedEmail from '../emails/attestation-received';
 
-import { c, getUpdateAuthor } from '../utils/misc';
+import { c, getLastPausedAtDate, getUpdateAuthor } from '../utils/misc';
 import { getAttestationByDate, isAttestable, sortByDate } from '../utils/calculations';
 
 export async function deleteDocument(
@@ -521,6 +521,7 @@ export async function search(params: SearchParams, identity: Identity): Promise<
         ...(app.approvedAtUtc && {
           attestationByUtc: getAttestationByDate(app.approvedAtUtc, config),
         }),
+        lastPausedAtUtc: getLastPausedAtDate(app),
       } as ApplicationSummary),
   );
 

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -46,7 +46,7 @@ import {
 } from './validations';
 import { BadRequest, ConflictError, NotFound } from '../utils/errors';
 import { AppConfig } from '../config';
-import { getUpdateAuthor, mergeKnown } from '../utils/misc';
+import { getLastPausedAtDate, getUpdateAuthor, mergeKnown } from '../utils/misc';
 import { getAttestationByDate, getDaysElapsed, isAttestable } from '../utils/calculations';
 
 const allSections: Array<keyof Application['sections']> = [
@@ -170,6 +170,9 @@ export class ApplicationStateManager {
       this.currentApplication,
       this.currentAppConfig,
     );
+
+    // adding to response for convenience in FE, so it doesn't need to parse value from updates array
+    this.currentApplication.lastPausedAtUtc = getLastPausedAtDate(this.currentApplication);
     return this.currentApplication;
   }
 


### PR DESCRIPTION
Adds most recent `PAUSED` update event from `updates` list to single app and app summary responses so FE doesn't need to find the value. The pause event is usually not the same as the `attestationByUtc` date, as the batch job runs the next day.
- also avoids the assumption that every pause event going forward is due to missed attestation