### PR TITLE
✨ 253 - add renewal transition for approved apps

### DIFF
--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -295,6 +295,7 @@ export type RevisionSections =
     >
   | 'general';
 export type RevisionRequestUpdate = Partial<Record<RevisionSections, RevisionRequest>>;
+
 export interface UpdateApplication {
   state?: State;
   expiresAtUtc?: Date;
@@ -302,6 +303,7 @@ export interface UpdateApplication {
   revisionRequest?: RevisionRequestUpdate;
   pauseReason?: PauseReason;
   isAttesting?: boolean;
+  isRenewal?: boolean;
   sections: {
     applicant?: {
       info?: Partial<PersonalInfo>;

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -523,6 +523,7 @@ export async function search(params: SearchParams, identity: Identity): Promise<
           attestationByUtc: getAttestationByDate(app.approvedAtUtc, config),
         }),
         lastPausedAtUtc: getLastPausedAtDate(app),
+        isRenewal: app.isRenewal,
       } as ApplicationSummary),
   );
 

--- a/src/domain/validations.ts
+++ b/src/domain/validations.ts
@@ -8,7 +8,6 @@ import {
   SectionError,
 } from './interface';
 import validator from 'validate.js';
-import _, { isNaN } from 'lodash';
 import { countriesList } from '../utils/constants';
 import { c } from '../utils/misc';
 

--- a/src/test/state.spec.ts
+++ b/src/test/state.spec.ts
@@ -672,7 +672,7 @@ describe('state manager', () => {
     expect(get(app, 'sections.signature.meta.lastUpdatedAtUtc')).to.not.be.undefined;
   }
 
-  it.only('should renew a renewable APPROVED application', () => {
+  it('should renew a renewable APPROVED application', () => {
     const app: Application = getApprovedApplication();
     const mockExpiryDate = moment(app.expiresAtUtc).subtract(20, 'days').toDate();
     app.expiresAtUtc = mockExpiryDate;
@@ -698,7 +698,7 @@ describe('state manager', () => {
     // TODO: EXPIRED state to be implemented
   });
 
-  it.only('should not renew a non-renewable application', () => {
+  it('should not renew a non-renewable application', () => {
     const app: Application = getApprovedApplication();
     expect(isRenewable(app, attestableConfig)).to.be.false;
     const state = new ApplicationStateManager(app, attestableConfig);
@@ -718,7 +718,27 @@ describe('state manager', () => {
   });
 
   it('should renew an application that has been previously renewed', () => {
-    // TODO: to be implemented
+    const app = getApprovedApplication();
+    const mockExpiryDate = moment(app.expiresAtUtc).subtract(20, 'days').toDate();
+    app.expiresAtUtc = mockExpiryDate;
+    app.isRenewal = true;
+    expect(isRenewable(app, attestableConfig)).to.be.true;
+
+    const state = new ApplicationStateManager(app, attestableConfig);
+
+    state.updateApp(
+      {
+        isRenewal: true,
+      },
+      false,
+      { id: '123', role: DacoRole.SUBMITTER },
+    );
+
+    const userApp = state.prepareApplicationForUser(false);
+    expect(userApp.isRenewal).to.be.true;
+    expect(userApp.state).to.eq('DRAFT');
+    verifyRenewedSectionsStatus(userApp);
+    expect(isRenewable(userApp, attestableConfig)).to.be.false;
   });
 });
 


### PR DESCRIPTION
Adds `isRenewal` to update application request
Creates renewal transition for renewable `APPROVED` applications*
Adds `isRenewal` field to `ApplicationSummary` response
Adds state tests
* handling transition for `EXPIRED` applications will be implemented in https://github.com/icgc-argo/dac-api/issues/252