### PR TITLE
✨ 250, 251 - implement expiry notification jobs

### DIFF
--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -1066,7 +1066,7 @@ async function sendAttestationReceivedEmail(
   );
 }
 
-async function sendAccessExpiringEmail(
+export async function sendAccessExpiringEmail(
   updatedApp: Application,
   config: AppConfig,
   daysToExpiry: number, // this will come from the cronjob that is executing, i.e. first (90 days) or second (45 days) warning

--- a/src/jobs/firstExpiryNotification.ts
+++ b/src/jobs/firstExpiryNotification.ts
@@ -1,6 +1,132 @@
+import { Transporter } from 'nodemailer';
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
+import moment from 'moment';
+import { FilterQuery } from 'mongoose';
+import { chunk } from 'lodash';
+
+import logger from '../logger';
+import { AppConfig, getAppConfig } from '../config';
+import { NOTIFICATION_UNIT_OF_TIME, REQUEST_CHUNK_SIZE } from '../utils/constants';
+import { ApplicationDocument, ApplicationModel } from '../domain/model';
+import { Application } from '../domain/interface';
+import { buildReportDetails, getEmptyReportDetails } from './utils';
+import { sendAccessExpiringEmail } from '../domain/service';
+import { getDayRange } from '../utils/calculations';
+import { BatchJobDetails, JobReport, JobResultForApplication } from './types';
+
 const JOB_NAME = 'FIRST EXPIRY NOTIFICATIONS';
+
 // 1st notification for applications entering renewal period (DAYS_TO_EXPIRY_1)
-export default async function () {
-  // TODO: implement
-  return;
+async function firstExpiryNotificationCheck(
+  currentDate: Date,
+  emailClient: Transporter<SMTPTransport.SentMessageInfo>,
+): Promise<JobReport<BatchJobDetails>> {
+  const config = await getAppConfig();
+  const startedAt = new Date();
+  try {
+    logger.info(`${JOB_NAME} - Initiating...`);
+    const details = await getReportDetails(currentDate, emailClient, config);
+    details.errors.length
+      ? logger.warn(`${JOB_NAME} - Completed with errors.`)
+      : logger.info(`${JOB_NAME} - Completed.`);
+    const finishedAt = new Date();
+    const jobSuccessReport: JobReport<BatchJobDetails> = {
+      jobName: JOB_NAME,
+      startedAt,
+      finishedAt,
+      success: true,
+      details,
+    };
+    logger.info(`${JOB_NAME} - Report: ${JSON.stringify(jobSuccessReport)}`);
+    return jobSuccessReport;
+  } catch (err) {
+    logger.error(`${JOB_NAME} - Failed to complete, with error: ${(err as Error).message}`);
+    const finishedAt = new Date();
+    const jobFailedReport: JobReport<BatchJobDetails> = {
+      jobName: JOB_NAME,
+      startedAt,
+      finishedAt,
+      success: false,
+      error: `${JOB_NAME} - Failed to complete, with error: ${(err as Error).message}`,
+    };
+    logger.error(`${JOB_NAME} - Report: ${JSON.stringify(jobFailedReport)}`);
+    return jobFailedReport;
+  }
 }
+
+const getReportDetails = async (
+  currentDate: Date,
+  emailClient: Transporter<SMTPTransport.SentMessageInfo>,
+  config: AppConfig,
+): Promise<BatchJobDetails> => {
+  const {
+    durations: {
+      expiry: { daysToExpiry1 },
+    },
+  } = config;
+  const query = getQuery(config, currentDate);
+  const appCount = await ApplicationModel.find(query).countDocuments();
+  if (appCount === 0) {
+    logger.info(`${JOB_NAME} - No applications are entering the renewal period.`);
+    logger.info(`${JOB_NAME} - Generating report.`);
+    return getEmptyReportDetails();
+  }
+  logger.info(`${JOB_NAME} - ${appCount} applications are entering the renewal period.`);
+  const renewableApps = await ApplicationModel.find(query).exec();
+  const apps: Application[] = renewableApps.map((app: ApplicationDocument) => {
+    return app.toObject();
+  });
+
+  logger.info(`${JOB_NAME} - Initiating email requests.`);
+  const sendNotification = async (app: Application): Promise<JobResultForApplication> => {
+    try {
+      await sendAccessExpiringEmail(app, config, daysToExpiry1, emailClient);
+      return { success: true, app };
+    } catch (err: unknown) {
+      // Error thrown in one of our async operations
+      logger.error(
+        `${JOB_NAME} - Error caught while sending first expiry notification email for ${app.appId} - ${err}`,
+      );
+      return { success: false, app, message: `${err}` };
+    }
+  };
+  const chunkedEmails = chunk(apps, REQUEST_CHUNK_SIZE);
+  const results: JobResultForApplication[][] = [];
+  for (const email of chunkedEmails) {
+    const result = await Promise.all(email.map(sendNotification));
+    results.push(result);
+  }
+  const allResults = results.flat();
+  logger.info(`${JOB_NAME} - Generating report.`);
+  const firstExpiryNotificationReport = buildReportDetails(
+    allResults,
+    'expiryNotifications1',
+    JOB_NAME,
+  );
+  return firstExpiryNotificationReport;
+};
+
+const getQuery = (config: AppConfig, currentDate: Date): FilterQuery<ApplicationDocument> => {
+  const {
+    durations: {
+      expiry: { count, unitOfTime, daysToExpiry1 },
+    },
+  } = config;
+  // find all apps that are APPROVED with an approval date matching the configured time period minus configured daysToExpiry1
+  // default is 2 year less 90 days to match DACO
+  const approvalStartDate = moment(currentDate)
+    .subtract(count, unitOfTime)
+    .add(daysToExpiry1, NOTIFICATION_UNIT_OF_TIME);
+  const approvalDayRange = getDayRange(approvalStartDate);
+  logger.info(
+    `${JOB_NAME} - Approval day period is ${approvalDayRange.$gte} to ${approvalDayRange.$lte}`,
+  );
+  const query: FilterQuery<ApplicationDocument> = {
+    state: 'APPROVED',
+    approvedAtUtc: approvalDayRange,
+  };
+
+  return query;
+};
+
+export default firstExpiryNotificationCheck;

--- a/src/jobs/runAllJobs.ts
+++ b/src/jobs/runAllJobs.ts
@@ -7,6 +7,8 @@ import logger from '../logger';
 import attestationRequiredNotification from './attestationRequiredNotification';
 import runPauseAppsCheck from './pauseAppCheck';
 import firstExpiryNotificationCheck from './firstExpiryNotification';
+import secondExpiryNotificationCheck from './secondExpiryNotification';
+
 import { Report, JobReport } from './types';
 
 const JOB_NAME = 'ALL BATCH JOBS';
@@ -29,6 +31,10 @@ export default async function (
       currentDate,
       emailClient,
     );
+    const secondExpiryNotificationReport = await secondExpiryNotificationCheck(
+      currentDate,
+      emailClient,
+    );
     // define report to collect all affected appIds
     // each job will return its own report
     // this function will build a complete summary
@@ -46,7 +52,7 @@ export default async function (
       pausedApps: pausedAppReport,
       // TODO: implement expiry/renewal jobs. Add to report
       expiryNotifications1: firstExpiryNotificationReport,
-      expiryNotifications2: getReportToBeImplemented('SECOND EXPIRY NOTIFICATIONS'),
+      expiryNotifications2: secondExpiryNotificationReport,
       expiredApps: getReportToBeImplemented('EXPIRING APPLICATIONS'),
     };
     logger.info(`${JOB_NAME} - Logging report`);

--- a/src/jobs/runAllJobs.ts
+++ b/src/jobs/runAllJobs.ts
@@ -6,6 +6,7 @@ import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import logger from '../logger';
 import attestationRequiredNotification from './attestationRequiredNotification';
 import runPauseAppsCheck from './pauseAppCheck';
+import firstExpiryNotificationCheck from './firstExpiryNotification';
 import { Report, JobReport } from './types';
 
 const JOB_NAME = 'ALL BATCH JOBS';
@@ -24,7 +25,10 @@ export default async function (
       emailClient,
     );
     const pausedAppReport = await runPauseAppsCheck(currentDate, emailClient, user);
-
+    const firstExpiryNotificationReport = await firstExpiryNotificationCheck(
+      currentDate,
+      emailClient,
+    );
     // define report to collect all affected appIds
     // each job will return its own report
     // this function will build a complete summary
@@ -41,7 +45,7 @@ export default async function (
       attestationNotifications: attestationNotificationReport,
       pausedApps: pausedAppReport,
       // TODO: implement expiry/renewal jobs. Add to report
-      expiryNotifications1: getReportToBeImplemented('FIRST EXPIRY NOTIFICATIONS'),
+      expiryNotifications1: firstExpiryNotificationReport,
       expiryNotifications2: getReportToBeImplemented('SECOND EXPIRY NOTIFICATIONS'),
       expiredApps: getReportToBeImplemented('EXPIRING APPLICATIONS'),
     };

--- a/src/jobs/secondExpiryNotification.ts
+++ b/src/jobs/secondExpiryNotification.ts
@@ -114,7 +114,7 @@ const getQuery = (config: AppConfig, currentDate: Date): FilterQuery<Application
   } = config;
   // find all apps that are APPROVED with an expiry date that is the configured daysToExpiry2 in the future
   // default is 2 years less 45 days to match DACO
-  // at this point an app approaching expiry may already be in the renewal flow, so we still limit query by APPROVED state, which indicates no action has been taken by the applicant
+  // at this point an app approaching expiry may already be in the renewal flow, so we query by APPROVED + any pre-REVIEW state
   // query uses expiresAtUtc, because this date may be custom (not matching the configured access period of 2 years)
   const expiryStartDate = moment(currentDate).add(daysToExpiry2, NOTIFICATION_UNIT_OF_TIME);
   const expiryDayRange = getDayRange(expiryStartDate);
@@ -122,7 +122,7 @@ const getQuery = (config: AppConfig, currentDate: Date): FilterQuery<Application
     `${JOB_NAME} - Expiry day period is ${expiryDayRange.$gte} to ${expiryDayRange.$lte}`,
   );
   const query: FilterQuery<ApplicationDocument> = {
-    state: 'APPROVED',
+    state: { $in: ['APPROVED', 'DRAFT', 'SIGN AND SUBMIT', 'REVISIONS REQUESTED'] },
     expiresAtUtc: expiryDayRange,
   };
 

--- a/src/jobs/secondExpiryNotification.ts
+++ b/src/jobs/secondExpiryNotification.ts
@@ -1,7 +1,132 @@
+import { Transporter } from 'nodemailer';
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
+import moment from 'moment';
+import { FilterQuery } from 'mongoose';
+import { chunk } from 'lodash';
+
+import logger from '../logger';
+import { AppConfig, getAppConfig } from '../config';
+import { NOTIFICATION_UNIT_OF_TIME, REQUEST_CHUNK_SIZE } from '../utils/constants';
+import { ApplicationDocument, ApplicationModel } from '../domain/model';
+import { Application } from '../domain/interface';
+import { buildReportDetails, getEmptyReportDetails } from './utils';
+import { sendAccessExpiringEmail } from '../domain/service';
+import { getDayRange } from '../utils/calculations';
+import { BatchJobDetails, JobReport, JobResultForApplication } from './types';
+
 const JOB_NAME = 'SECOND EXPIRY NOTIFICATIONS';
 
 // 2nd notification for applications that have not begun renewal process (DAYS_TO_EXPIRY_2)
-export default async function () {
-  // TODO: implement
-  return;
+async function secondExpiryNotificationCheck(
+  currentDate: Date,
+  emailClient: Transporter<SMTPTransport.SentMessageInfo>,
+): Promise<JobReport<BatchJobDetails>> {
+  const config = await getAppConfig();
+  const startedAt = new Date();
+  try {
+    logger.info(`${JOB_NAME} - Initiating...`);
+    const details = await getReportDetails(currentDate, emailClient, config);
+    details.errors.length
+      ? logger.warn(`${JOB_NAME} - Completed with errors.`)
+      : logger.info(`${JOB_NAME} - Completed.`);
+    const finishedAt = new Date();
+    const jobSuccessReport: JobReport<BatchJobDetails> = {
+      jobName: JOB_NAME,
+      startedAt,
+      finishedAt,
+      success: true,
+      details,
+    };
+    logger.info(`${JOB_NAME} - Report: ${JSON.stringify(jobSuccessReport)}`);
+    return jobSuccessReport;
+  } catch (err) {
+    logger.error(`${JOB_NAME} - Failed to complete, with error: ${(err as Error).message}`);
+    const finishedAt = new Date();
+    const jobFailedReport: JobReport<BatchJobDetails> = {
+      jobName: JOB_NAME,
+      startedAt,
+      finishedAt,
+      success: false,
+      error: `${JOB_NAME} - Failed to complete, with error: ${(err as Error).message}`,
+    };
+    logger.error(`${JOB_NAME} - Report: ${JSON.stringify(jobFailedReport)}`);
+    return jobFailedReport;
+  }
 }
+
+const getReportDetails = async (
+  currentDate: Date,
+  emailClient: Transporter<SMTPTransport.SentMessageInfo>,
+  config: AppConfig,
+): Promise<BatchJobDetails> => {
+  const {
+    durations: {
+      expiry: { daysToExpiry2 },
+    },
+  } = config;
+  const query = getQuery(config, currentDate);
+  const appCount = await ApplicationModel.find(query).countDocuments();
+  if (appCount === 0) {
+    logger.info(`${JOB_NAME} - No applications require a second expiry notification.`);
+    logger.info(`${JOB_NAME} - Generating report.`);
+    return getEmptyReportDetails();
+  }
+  logger.info(`${JOB_NAME} - ${appCount} applications require a second expiry notification.`);
+  const renewableApps = await ApplicationModel.find(query).exec();
+  const apps: Application[] = renewableApps.map((app: ApplicationDocument) => {
+    return app.toObject();
+  });
+
+  logger.info(`${JOB_NAME} - Initiating email requests.`);
+  const sendNotification = async (app: Application): Promise<JobResultForApplication> => {
+    try {
+      await sendAccessExpiringEmail(app, config, daysToExpiry2, emailClient);
+      return { success: true, app };
+    } catch (err: unknown) {
+      // Error thrown in one of our async operations
+      logger.error(
+        `${JOB_NAME} - Error caught while sending second expiry notification email for ${app.appId} - ${err}`,
+      );
+      return { success: false, app, message: `${err}` };
+    }
+  };
+  const chunkedEmails = chunk(apps, REQUEST_CHUNK_SIZE);
+  const results: JobResultForApplication[][] = [];
+  for (const email of chunkedEmails) {
+    const result = await Promise.all(email.map(sendNotification));
+    results.push(result);
+  }
+  const allResults = results.flat();
+  logger.info(`${JOB_NAME} - Generating report.`);
+  const firstExpiryNotificationReport = buildReportDetails(
+    allResults,
+    'expiryNotifications2',
+    JOB_NAME,
+  );
+  return firstExpiryNotificationReport;
+};
+
+const getQuery = (config: AppConfig, currentDate: Date): FilterQuery<ApplicationDocument> => {
+  const {
+    durations: {
+      expiry: { daysToExpiry2 },
+    },
+  } = config;
+  // find all apps that are APPROVED with an expiry date that is the configured daysToExpiry2 in the future
+  // default is 2 years less 45 days to match DACO
+  // at this point an app approaching expiry may already be in the renewal flow, so we still limit query by APPROVED state, which indicates no action has been taken by the applicant
+  // query uses expiresAtUtc, because this date may be custom (not matching the configured access period of 2 years)
+  const expiryStartDate = moment(currentDate).add(daysToExpiry2, NOTIFICATION_UNIT_OF_TIME);
+  const expiryDayRange = getDayRange(expiryStartDate);
+  logger.info(
+    `${JOB_NAME} - Expiry day period is ${expiryDayRange.$gte} to ${expiryDayRange.$lte}`,
+  );
+  const query: FilterQuery<ApplicationDocument> = {
+    state: 'APPROVED',
+    expiresAtUtc: expiryDayRange,
+  };
+
+  return query;
+};
+
+export default secondExpiryNotificationCheck;

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -67,6 +67,8 @@ export const isRenewable: (currentApp: Application, config: AppConfig) => boolea
     return false;
   }
   const now = moment.utc();
+
+  // need to calculate renewability relative to expiry date, because this date may be custom (not matching the configured access period of 2 years)
   // expiry - DAYS_TO_EXPIRY_1
   const expiryPeriodStart = moment
     .utc(currentApp.expiresAtUtc)


### PR DESCRIPTION
Implements job functions for first (#250 ) and second (#251 ) expiry notifications
- db queries are done with `expiresAtUtc` value as this is a stored value, and may not always be the configured access period of 2 years
- second notification adds `DRAFT`, `SIGN AND SUBMIT`, and `REVISIONS REQUESTED` states to its query as we want to send a reminder to applicants who have started but not completed the renewal flow