### PR TITLE
🏷️ Token middleware fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.18.0",
         "@aws-sdk/s3-request-presigner": "^3.18.0",
-        "@overture-stack/ego-token-middleware": "^2.4.0",
+        "@overture-stack/ego-token-middleware": "^2.4.1",
         "archiver": "^5.3.0",
         "aws-sdk": "^2.923.0",
         "body-parser": "^1.19.0",
@@ -1759,9 +1759,9 @@
       }
     },
     "node_modules/@overture-stack/ego-token-middleware": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@overture-stack/ego-token-middleware/-/ego-token-middleware-2.4.0.tgz",
-      "integrity": "sha512-fi8lNv0cLYhIg0+HDI2bsUE1JL9UJVH28ApFcJmVLeZNGbycHOGswgjPhEV8S0gMSPqhkL3ziSkaDzwfWsqW/g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@overture-stack/ego-token-middleware/-/ego-token-middleware-2.4.1.tgz",
+      "integrity": "sha512-bqZxmdwE5p1rF/ClhDfXCkfJI40GI09XZZKn4rA58+xgx/L0z0OaGbqka8jgXS2ak8MmP4JqGWhjlyXZZK7AxQ==",
       "dependencies": {
         "axios": "^1.0.0",
         "jsonwebtoken": "^8.5.1",
@@ -11392,9 +11392,9 @@
       }
     },
     "@overture-stack/ego-token-middleware": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@overture-stack/ego-token-middleware/-/ego-token-middleware-2.4.0.tgz",
-      "integrity": "sha512-fi8lNv0cLYhIg0+HDI2bsUE1JL9UJVH28ApFcJmVLeZNGbycHOGswgjPhEV8S0gMSPqhkL3ziSkaDzwfWsqW/g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@overture-stack/ego-token-middleware/-/ego-token-middleware-2.4.1.tgz",
+      "integrity": "sha512-bqZxmdwE5p1rF/ClhDfXCkfJI40GI09XZZKn4rA58+xgx/L0z0OaGbqka8jgXS2ak8MmP4JqGWhjlyXZZK7AxQ==",
       "requires": {
         "axios": "^1.0.0",
         "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.18.0",
     "@aws-sdk/s3-request-presigner": "^3.18.0",
-    "@overture-stack/ego-token-middleware": "^2.4.0",
+    "@overture-stack/ego-token-middleware": "^2.4.1",
     "archiver": "^5.3.0",
     "aws-sdk": "^2.923.0",
     "body-parser": "^1.19.0",

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -346,6 +346,11 @@ export interface UpdateApplication {
   };
 }
 
+export interface SubmitterInfo {
+  userId: string;
+  email: string;
+}
+
 export enum FileFormat {
   DACO_FILE_FORMAT = 'daco-file-format',
 }

--- a/src/domain/service/applications/index.ts
+++ b/src/domain/service/applications/index.ts
@@ -43,12 +43,12 @@ import {
 } from '../emails';
 import { findApplication } from './search';
 import { hasReviewScope, getUpdateAuthor } from '../../../utils/permissions';
-import { throwApplicationClosedError } from '../../../utils/errors';
+import { Forbidden, throwApplicationClosedError } from '../../../utils/errors';
 
 export async function create(identity: UserIdentity) {
   const isAdminOrReviewerResult = hasReviewScope(identity);
   if (isAdminOrReviewerResult) {
-    throw new Error('not allowed');
+    throw new Forbidden('User is not allowed to perform this action');
   }
   const app = newApplication(identity);
   const appDoc = await ApplicationModel.create(app);


### PR DESCRIPTION
Updates ego-token-middleware to `2.4.1`
Adds function to extract submitter info with verified email, to account for middleware type changes.
Throws error if email is not present when creating an application.