### PR TITLE
✨ 364 - renewal request

### DIFF
--- a/dac-api-compose/docker-compose.yaml
+++ b/dac-api-compose/docker-compose.yaml
@@ -17,17 +17,21 @@ services:
       VAULT_ADDR: http://0.0.0.0:8200
       VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
 
+  # local replica setup modified from https://github.com/bitnami/containers/blob/main/bitnami/mongodb/docker-compose-replicaset.yml
   mongodb:
     image: 'bitnami/mongodb:4.0'
     ports:
       - '27027:27017'
+    environment:
+      - MONGODB_ADVERTISED_HOSTNAME=mongodb
+      - MONGODB_REPLICA_SET_MODE=primary
+      - MONGODB_ROOT_PASSWORD=password123
+      - MONGODB_REPLICA_SET_KEY=replicasetkey123
+      - MONGODB_USERNAME=admin
+      - MONGODB_PASSWORD=password
+      - MONGODB_DATABASE=appdb
     volumes:
       - 'mongodb_data:/bitnami'
-    environment:
-      MONGODB_USERNAME: admin
-      MONGODB_PASSWORD: password
-      MONGODB_DATABASE: appdb
-      MONGODB_ROOT_PASSWORD: password123
 
   object-storage:
     image: minio/minio
@@ -37,17 +41,17 @@ services:
       MINIO_SECRET_KEY: minio123
     command: server /data
     ports:
-      - "8085:9000"
+      - '8085:9000'
     volumes:
       - 'minio_data:/data'
-      
+
   # for email services
   mailhog:
     image: mailhog/mailhog
     container_name: 'mailhog'
     ports:
-      - "1025:1025"
-      - "8025:8025"      
+      - '1025:1025'
+      - '8025:8025'
 
 volumes:
   mongodb_data:

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -323,7 +323,6 @@ export interface UpdateApplication {
   revisionRequest?: RevisionRequestUpdate;
   pauseReason?: PauseReason;
   isAttesting?: boolean;
-  isRenewing?: boolean;
   sections: {
     applicant?: {
       info?: Partial<PersonalInfo>;

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -285,6 +285,8 @@ export interface Application {
   pauseReason?: PauseReason | null;
   lastPausedAtUtc?: Date;
   emailNotifications?: NotificationSentFlags;
+  sourceAppId?: string; // appId of original application, added to a renewal application
+  renewalAppId?: string; // appId of renewal application, added to the original application
 }
 
 export type AppSections = keyof Application['sections'];
@@ -317,6 +319,7 @@ export interface UpdateApplication {
   revisionRequest?: RevisionRequestUpdate;
   pauseReason?: PauseReason;
   isAttesting?: boolean;
+  isRenewing?: boolean;
   sections: {
     applicant?: {
       info?: Partial<PersonalInfo>;

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -178,6 +178,9 @@ export interface ApplicationSummary {
   isAttestable: boolean;
   ableToRenew: boolean;
   lastPausedAtUtc?: Date;
+  sourceAppId?: string;
+  renewalAppId?: string;
+  renewalPeriodEndDateUtc?: Date;
 }
 
 export type ApplicationDto = Omit<Application, 'searchField'>;
@@ -263,7 +266,7 @@ export interface Application {
   createdAtUtc?: Date;
   searchValues: string[];
   isRenewal: boolean;
-  ableToRenew: boolean;
+  ableToRenew: boolean; // calculated
   // calculated flag to indicate that revisions are being requested if any of the revisionRequest sections is true
   // and this flag will be reset before each review since we do reset the revision request portion.
   revisionsRequested: boolean;
@@ -281,12 +284,13 @@ export interface Application {
   approvedAppDocs: ApprovedAppDocument[];
   attestationByUtc?: Date; // calculated from approvedAtUtc
   attestedAtUtc?: Date | null;
-  isAttestable: boolean;
+  isAttestable: boolean; // calculated
   pauseReason?: PauseReason | null;
-  lastPausedAtUtc?: Date;
+  lastPausedAtUtc?: Date; // calculated
   emailNotifications?: NotificationSentFlags;
   sourceAppId?: string; // appId of original application, added to a renewal application
   renewalAppId?: string; // appId of renewal application, added to the original application
+  renewalPeriodEndDateUtc?: Date; // source app expiresAtUtc + daysPostExpiry
 }
 
 export type AppSections = keyof Application['sections'];

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -196,6 +196,7 @@ const ApplicationSchema = new mongoose.Schema(
     emailNotifications: NotificationSentFlags,
     sourceAppId: { type: String, required: false },
     renewalAppId: { type: String, required: false },
+    renewalPeriodEndDateUtc: { type: Date, required: false },
   },
   {
     timestamps: {

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -194,6 +194,8 @@ const ApplicationSchema = new mongoose.Schema(
     updates: [ApplicationUpdate],
     approvedAppDocs: [ApprovedAppDocument],
     emailNotifications: NotificationSentFlags,
+    sourceAppId: { type: String, required: false },
+    renewalAppId: { type: String, required: false },
   },
   {
     timestamps: {

--- a/src/domain/service/applications/index.ts
+++ b/src/domain/service/applications/index.ts
@@ -189,7 +189,7 @@ async function checkDeletedDocuments(originalApp: Application, updatedApp: Appli
   // we check that objectIds are unique, to ensure they are not deleted from object storage if associated with another application
   const uniqueEthicsIds: string[] = [];
   for await (const id of ethicsDiff) {
-    const isUnique = await isEthicsDocReferenced(id);
+    const isUnique = await !isEthicsDocReferenced(id);
     if (isUnique) {
       uniqueEthicsIds.push(id);
     }

--- a/src/domain/service/applications/search.ts
+++ b/src/domain/service/applications/search.ts
@@ -264,10 +264,10 @@ export async function getById(id: string, identity: Identity) {
   }
   const app = apps[0];
   const copy = app.toObject();
-  const viewAbleApplication = new ApplicationStateManager(copy).prepareApplicationForUser(
+  const viewableApplication = new ApplicationStateManager(copy).prepareApplicationForUser(
     isAdminOrReviewerResult,
   );
-  return viewAbleApplication;
+  return viewableApplication;
 }
 
 export async function findApplication(appId: string, identity: Identity) {
@@ -351,3 +351,11 @@ export const getUsersFromApprovedApps = async (): Promise<
     return approvedUsersInfo;
   });
 };
+
+export async function checkEthicsDocWasUnique(objectId: string): Promise<boolean> {
+  const query: FilterQuery<ApplicationDocument> = {
+    'sections.ethicsLetter.approvalLetterDocs': { $elemMatch: { objectId: objectId } },
+  };
+  const result = await ApplicationModel.countDocuments(query).exec();
+  return result === 0;
+}

--- a/src/domain/service/applications/search.ts
+++ b/src/domain/service/applications/search.ts
@@ -352,7 +352,10 @@ export const getUsersFromApprovedApps = async (): Promise<
   });
 };
 
-export async function checkEthicsDocWasUnique(objectId: string): Promise<boolean> {
+/**
+ * For an ethics document objectId, find if the number of references in the applications collection is zero
+ */
+export async function isEthicsDocReferenced(objectId: string): Promise<boolean> {
   const query: FilterQuery<ApplicationDocument> = {
     'sections.ethicsLetter.approvalLetterDocs': { $elemMatch: { objectId: objectId } },
   };

--- a/src/domain/service/applications/search.ts
+++ b/src/domain/service/applications/search.ts
@@ -192,6 +192,9 @@ export async function search(params: SearchParams, identity: Identity): Promise<
         }),
         lastPausedAtUtc: getLastPausedAtDate(app),
         isRenewal: app.isRenewal,
+        sourceAppId: app.sourceAppId,
+        renewalAppId: app.renewalAppId,
+        renewalPeriodEndDateUtc: app.renewalPeriodEndDateUtc,
       } as ApplicationSummary),
   );
 

--- a/src/domain/service/applications/search.ts
+++ b/src/domain/service/applications/search.ts
@@ -353,12 +353,12 @@ export const getUsersFromApprovedApps = async (): Promise<
 };
 
 /**
- * For an ethics document objectId, find if the number of references in the applications collection is zero
+ * For an ethics document objectId, find if the number of references in the applications collection is greater than zero
  */
 export async function isEthicsDocReferenced(objectId: string): Promise<boolean> {
   const query: FilterQuery<ApplicationDocument> = {
     'sections.ethicsLetter.approvalLetterDocs': { $elemMatch: { objectId: objectId } },
   };
   const result = await ApplicationModel.countDocuments(query).exec();
-  return result === 0;
+  return result > 0;
 }

--- a/src/domain/service/files.ts
+++ b/src/domain/service/files.ts
@@ -65,7 +65,7 @@ export async function deleteDocument(
   await ApplicationModel.updateOne({ appId: result.appId }, result);
   // if doc type is ethics letter, check if the objectId is referenced in another application
   // if not referenced elsewhere, it is safe to delete from object storage
-  const shouldDeleteFile = type === 'ETHICS' ? await isEthicsDocReferenced(objectId) : true;
+  const shouldDeleteFile = type === 'ETHICS' ? await !isEthicsDocReferenced(objectId) : true;
   if (shouldDeleteFile) {
     logger.info(`File with objectId [${objectId}] was unique, can delete from storage`);
     // delete the file from object storage

--- a/src/domain/service/files.ts
+++ b/src/domain/service/files.ts
@@ -40,7 +40,7 @@ import {
 import { Storage } from '../../storage';
 import logger, { buildMessage } from '../../logger';
 import {
-  checkEthicsDocWasUnique,
+  isEthicsDocReferenced,
   findApplication,
   getApplicationUpdates,
   getUsersFromApprovedApps,
@@ -65,10 +65,7 @@ export async function deleteDocument(
   await ApplicationModel.updateOne({ appId: result.appId }, result);
   // if doc type is ethics letter, check if the objectId is referenced in another application
   // if not referenced elsewhere, it is safe to delete from object storage
-  let shouldDeleteFile = true;
-  if (type === 'ETHICS') {
-    shouldDeleteFile = await checkEthicsDocWasUnique(objectId);
-  }
+  const shouldDeleteFile = type === 'ETHICS' ? await isEthicsDocReferenced(objectId) : true;
   if (shouldDeleteFile) {
     logger.info(`File with objectId [${objectId}] was unique, can delete from storage`);
     // delete the file from object storage

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -639,9 +639,10 @@ export function renewalApplication(
   identity: UserIdentity,
   originalApp: Application,
 ): Partial<Application> {
+  const submitter = getSubmitterInfo(identity);
   const newApplication: Partial<Application> = {
-    submitterId: originalApp.submitterId,
-    submitterEmail: originalApp.submitterEmail,
+    submitterId: submitter.userId,
+    submitterEmail: submitter.email,
     state: 'DRAFT',
     revisionRequest: emptyRevisionRequest(),
     sections: {

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -75,6 +75,7 @@ import {
 } from '../utils/calculations';
 import { getLastPausedAtDate, mergeKnown } from '../utils/misc';
 import { getUpdateAuthor, hasDacoSystemScope, hasReviewScope } from '../utils/permissions';
+import { NOTIFICATION_UNIT_OF_TIME } from '../utils/constants';
 
 const allSections: Array<keyof Application['sections']> = [
   'appendices',
@@ -91,7 +92,7 @@ const allSections: Array<keyof Application['sections']> = [
  * Array contains mapping that will govern which sections should be marked as locked
  * depending on which state we are and the role the viewer has.
  *
- * for example applicaions in review are completely locked for applicants but partially locked for admins.
+ * for example, applications in review are completely locked for applicants but partially locked for admins.
  */
 const stateToLockedSectionsMap: Record<
   State,
@@ -526,6 +527,13 @@ export class ApplicationStateManager {
     return current;
   }
 
+  updateAsRenewed(renewalId: string): Application {
+    const current = this.currentApplication;
+    current.renewalAppId = renewalId;
+    onAppUpdate(current);
+    return current;
+  }
+
   updateEmailNotifications(notificationType: keyof NotificationSentFlags): Application {
     const current = this.currentApplication;
     if (!current.emailNotifications) {
@@ -598,6 +606,8 @@ export function getSearchFieldValues(appDoc: Application) {
     appDoc.sections.applicant.info.primaryAffiliation,
     appDoc.sections.applicant.address.country,
     appDoc.isRenewal ? AppType.RENEWAL : AppType.NEW,
+    appDoc.renewalAppId ? appDoc.renewalAppId : '', // empty string will be filtered
+    appDoc.sourceAppId ? appDoc.sourceAppId : '', // empty string will be filtered
   ].filter((x) => !(x === null || x === undefined || x.trim() === ''));
 }
 
@@ -610,14 +620,68 @@ function getSubmitterInfo(identity: UserIdentity): SubmitterInfo {
     throw new Forbidden('A submitter email is required to create a new application.');
   }
 }
+
+function getPristineMeta(): Meta {
+  return { status: 'PRISTINE', errorsList: [] };
+}
+
+export function getRenewalPeriodEndDate(expiry: Date): Date {
+  const {
+    durations: {
+      expiry: { daysPostExpiry },
+    },
+  } = getAppConfig();
+  const endDate = moment.utc(expiry).add(daysPostExpiry, NOTIFICATION_UNIT_OF_TIME).endOf('day');
+  return endDate.toDate();
+}
+
+export function renewalApplication(
+  identity: UserIdentity,
+  originalApp: Application,
+): Partial<Application> {
+  const newApplication: Partial<Application> = {
+    submitterId: originalApp.submitterId,
+    submitterEmail: originalApp.submitterEmail,
+    state: 'DRAFT',
+    revisionRequest: emptyRevisionRequest(),
+    sections: {
+      ...originalApp.sections,
+      appendices: {
+        meta: getPristineMeta(),
+        agreements: getAppendixAgreements(),
+      },
+      dataAccessAgreement: {
+        meta: getPristineMeta(),
+        agreements: getDataAccessAgreement(),
+      },
+      signature: {
+        meta: {
+          status: 'DISABLED',
+          errorsList: [],
+        },
+        signedAppDocObjId: '',
+        signedDocName: '',
+      },
+    },
+    updates: [],
+    isRenewal: true,
+    sourceAppId: originalApp.appId,
+    renewalPeriodEndDateUtc: getRenewalPeriodEndDate(originalApp.expiresAtUtc),
+  };
+
+  const author = getUpdateAuthor(identity);
+  const createdEvent = createUpdateEvent(
+    newApplication as Application,
+    author,
+    UpdateEvent.CREATED,
+  );
+  newApplication.updates?.push(createdEvent);
+  return newApplication;
+}
+
 // new applications can only be created by user jwt identities
 export function newApplication(identity: UserIdentity): Partial<Application> {
   const submitter = getSubmitterInfo(identity);
-  const pristineMeta = {
-    status: 'PRISTINE' as SectionStatus,
-    errorsList: [],
-  } as Meta;
-
   const app: Partial<Application> = {
     state: 'DRAFT',
     submitterId: submitter.userId,
@@ -625,19 +689,19 @@ export function newApplication(identity: UserIdentity): Partial<Application> {
     revisionRequest: emptyRevisionRequest(),
     sections: {
       collaborators: {
-        meta: pristineMeta,
+        meta: getPristineMeta(),
         list: [],
       },
       appendices: {
-        meta: pristineMeta,
+        meta: getPristineMeta(),
         agreements: getAppendixAgreements(),
       },
       dataAccessAgreement: {
-        meta: pristineMeta,
+        meta: getPristineMeta(),
         agreements: getDataAccessAgreement(),
       },
       applicant: {
-        meta: pristineMeta,
+        meta: getPristineMeta(),
         address: {
           building: '',
           cityAndProvince: '',
@@ -667,13 +731,13 @@ export function newApplication(identity: UserIdentity): Partial<Application> {
         title: '',
         summary: '',
         publicationsURLs: [],
-        meta: pristineMeta,
+        meta: getPristineMeta(),
       },
       ethicsLetter: {
         // tslint:disable-next-line:no-null-keyword
         declaredAsRequired: null,
         approvalLetterDocs: [],
-        meta: pristineMeta,
+        meta: getPristineMeta(),
       },
       representative: {
         address: {
@@ -697,7 +761,7 @@ export function newApplication(identity: UserIdentity): Partial<Application> {
           suffix: '',
           title: '',
         },
-        meta: pristineMeta,
+        meta: getPristineMeta(),
       },
       signature: {
         meta: {
@@ -710,7 +774,6 @@ export function newApplication(identity: UserIdentity): Partial<Application> {
     },
     updates: [],
     isRenewal: false,
-    ableToRenew: false,
   };
 
   const author = getUpdateAuthor(identity);

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -608,7 +608,7 @@ export function getSearchFieldValues(appDoc: Application) {
     appDoc.isRenewal ? AppType.RENEWAL : AppType.NEW,
     appDoc.renewalAppId ? appDoc.renewalAppId : '', // empty string will be filtered
     appDoc.sourceAppId ? appDoc.sourceAppId : '', // empty string will be filtered
-  ].filter((x) => !(x === null || x === undefined || x.trim() === ''));
+  ].filter((x) => x && x.trim());
 }
 
 function getSubmitterInfo(identity: UserIdentity): SubmitterInfo {

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -307,6 +307,25 @@ paths:
         '204':
           description: deleted successfully
 
+  /applications/{id}/renew:
+    parameters:
+      - name: id
+        required: true
+        in: path
+        schema:
+          type: string
+    post:
+      tags:
+        - Application
+      summary: Create a renewal application by application ID
+      responses:
+        '201':
+          description: application updated and returned in the response body, renewal application created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+
   /applications/{id}/collaborators/:
     parameters:
       - name: id
@@ -730,6 +749,16 @@ components:
         attestedAtUtc:
           type: string
           format: data-time
+        renewalAppId:
+          readOnly: true
+          type: string
+        sourceAppId:
+          readOnly: true
+          type: string
+        renewalPeriodEndDateUtc:
+          readOnly: true
+          type: string
+          format: data-time
 
     Application:
       type: object
@@ -796,6 +825,16 @@ components:
           type: string
           format: data-time
         attestedAtUtc:
+          type: string
+          format: data-time
+        renewalAppId:
+          readOnly: true
+          type: string
+        sourceAppId:
+          readOnly: true
+          type: string
+        renewalPeriodEndDateUtc:
+          readOnly: true
           type: string
           format: data-time
         revisionRequests:

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -93,7 +93,7 @@ export class Storage {
       Key: objectId,
       Expires: 300,
     });
-
+    logger.info(`Deleting file with id: ${objectId}`);
     const response = await fetch(url, {
       method: 'DELETE',
     });

--- a/src/test/state.spec.ts
+++ b/src/test/state.spec.ts
@@ -1,6 +1,6 @@
 import { UserIdentity } from '@overture-stack/ego-token-middleware';
 import { expect } from 'chai';
-import { isDate, pick, cloneDeep, omit, get, every, set } from 'lodash';
+import { isDate, pick, cloneDeep, omit, get, every, set, isEqual } from 'lodash';
 import moment, { unitOfTime } from 'moment';
 
 import {
@@ -12,7 +12,7 @@ import {
   PauseReason,
   UpdateApplication,
 } from '../domain/interface';
-import { ApplicationStateManager, newApplication } from '../domain/state';
+import { ApplicationStateManager, newApplication, renewalApplication } from '../domain/state';
 import { BadRequest, ConflictError, Forbidden } from '../utils/errors';
 import { checkIsDefined } from '../utils/misc';
 import { NOTIFICATION_UNIT_OF_TIME } from '../utils/constants';
@@ -652,49 +652,45 @@ describe('state manager', () => {
     expect(userApp.attestedAtUtc).to.eq(undefined);
   });
 
-  function verifyRenewedSectionsStatus(app: Application): void {
+  function verifyRenewedSectionsStatus(
+    renewalApp: Partial<Application>,
+    sourceApp: Application,
+  ): void {
+    expect(isEqual(renewalApp?.sections?.applicant, sourceApp.sections?.applicant)).to.be.true;
+    expect(isEqual(renewalApp?.sections?.representative, sourceApp.sections?.representative)).to.be
+      .true;
+    expect(isEqual(renewalApp?.sections?.collaborators, sourceApp.sections?.collaborators)).to.be
+      .true;
+    expect(isEqual(renewalApp?.sections?.projectInfo, sourceApp.sections?.projectInfo)).to.be.true;
+    expect(isEqual(renewalApp?.sections?.ethicsLetter, sourceApp.sections?.ethicsLetter)).to.be
+      .true;
+
+    expect(get(renewalApp, 'sections.appendices.meta.status')).to.eq('PRISTINE');
+    expect(
+      every(get(renewalApp, 'sections.appendices.agreements'), (ag: AgreementItem) => !ag.accepted),
+    ).to.be.true;
+    expect(get(renewalApp, 'sections.appendices.meta.lastUpdatedAtUtc')).to.be.undefined;
+    expect(get(renewalApp, 'sections.dataAccessAgreement.meta.status')).to.eq('PRISTINE');
     expect(
       every(
-        pick(app.sections, [
-          'applicant',
-          'representative',
-          'projectInfo',
-          'ethicsLetter',
-          'collaborators',
-        ]),
-        (section) => section.meta.status === 'COMPLETE',
-      ),
-    ).is.true;
-    expect(get(app, 'sections.appendices.meta.status')).to.eq('PRISTINE');
-    expect(every(get(app, 'sections.appendices.agreements'), (ag: AgreementItem) => !ag.accepted))
-      .to.be.true;
-    expect(get(app, 'sections.appendices.meta.lastUpdatedAtUtc')).to.not.be.undefined;
-    expect(get(app, 'sections.dataAccessAgreement.meta.status')).to.eq('PRISTINE');
-    expect(
-      every(
-        get(app, 'sections.dataAccessAgreement.agreements'),
+        get(renewalApp, 'sections.dataAccessAgreement.agreements'),
         (ag: AgreementItem) => !ag.accepted,
       ),
     ).to.be.true;
-    expect(get(app, 'sections.dataAccessAgreement.meta.lastUpdatedAtUtc')).to.not.be.undefined;
-    expect(get(app, 'sections.signature.meta.status')).to.eq('DISABLED');
-    expect(get(app, 'sections.signature.meta.lastUpdatedAtUtc')).to.not.be.undefined;
+    expect(get(renewalApp, 'sections.dataAccessAgreement.meta.lastUpdatedAtUtc')).to.be.undefined;
+    expect(get(renewalApp, 'sections.signature.meta.status')).to.eq('DISABLED');
+    expect(get(renewalApp, 'sections.signature.meta.lastUpdatedAtUtc')).to.be.undefined;
+    expect(renewalApp.sourceAppId).to.eq(sourceApp.appId);
+    expect(sourceApp.renewalAppId).to.eq(renewalApp.appId);
+    expect(renewalApp.isRenewal).to.be.true;
+    expect(renewalApp.renewalPeriodEndDateUtc).to.not.be.undefined;
+    expect(renewalApp.state).to.eq('DRAFT');
   }
 
-  it('should renew a renewable APPROVED application', () => {
-    // TODO: implement
-  });
-
-  it('should renew an EXPIRED application', () => {
-    // TODO: EXPIRED state to be implemented
-  });
-
-  it('should not renew a non-renewable application', () => {
-    // TODO: implement
-  });
-
-  it('should renew an application that has been previously renewed', () => {
-    // TODO: implement
+  it('should create a renewal app from an existing application', () => {
+    const app = getApprovedApplication();
+    const renewalApp = renewalApplication(mockApplicantToken as UserIdentity, app);
+    verifyRenewedSectionsStatus(renewalApp, app);
   });
 });
 

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -208,5 +208,19 @@ describe('utils', () => {
       const canRenew = isRenewable(app);
       expect(canRenew).to.be.true;
     });
+
+    it('should be renewable in PAUSED state', () => {
+      const app = getPausedApplication();
+      expect(app.expiresAtUtc).to.not.eq(undefined);
+      const mockExpiresAtUtc = moment.utc().add(75, 'days');
+      app.expiresAtUtc = mockExpiresAtUtc.toDate();
+      const canRenew = isRenewable(app);
+      expect(canRenew).to.be.true;
+    });
+
+    // TODO: implement
+    it('should not be renewable if a renewal app has already been created', () => {});
+    // TODO: implement
+    it('should be renewable in EXPIRED state', () => {});
   });
 });

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -53,10 +53,13 @@ export const isAttestable: (currentApp: Application) => boolean = (currentApp) =
 };
 
 export const isRenewable: (currentApp: Application) => boolean = (currentApp) => {
-  // if the user has already started the renewal process, app state will be in DRAFT, SIGN AND SUBMIT, REVIEW or REVISIONS REQUESTED,
-  // so need to look for apps still in APPROVED or EXPIRED state, which means no action has been taken yet
-  // TODO: verify whether PAUSED apps can be renewed
-  if (!(currentApp.expiresAtUtc && ['APPROVED', 'EXPIRED'].includes(currentApp.state))) {
+  // can only renew an app in these states
+  if (!(currentApp.expiresAtUtc && ['APPROVED', 'EXPIRED', 'PAUSED'].includes(currentApp.state))) {
+    return false;
+  }
+  // can only create one renewal application
+  // TODO: should this id be deletable if the renewal app is accidentally closed before approval?
+  if (currentApp.renewalAppId) {
     return false;
   }
   const config = getAppConfig();

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -57,8 +57,7 @@ export const isRenewable: (currentApp: Application) => boolean = (currentApp) =>
   if (!(currentApp.expiresAtUtc && ['APPROVED', 'EXPIRED', 'PAUSED'].includes(currentApp.state))) {
     return false;
   }
-  // can only create one renewal application
-  // TODO: should this id be deletable if the renewal app is accidentally closed before approval?
+  // can only create one renewal application per source application
   if (currentApp.renewalAppId) {
     return false;
   }

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -54,11 +54,16 @@ export const isAttestable: (currentApp: Application) => boolean = (currentApp) =
 
 export const isRenewable: (currentApp: Application) => boolean = (currentApp) => {
   // can only renew an app in these states
-  if (!(currentApp.expiresAtUtc && ['APPROVED', 'EXPIRED', 'PAUSED'].includes(currentApp.state))) {
+  if (!['APPROVED', 'EXPIRED', 'PAUSED'].includes(currentApp.state)) {
     return false;
   }
   // can only create one renewal application per source application
   if (currentApp.renewalAppId) {
+    return false;
+  }
+
+  // must have expiresAtUtc value to check renewal period eligibility
+  if (!currentApp.expiresAtUtc) {
     return false;
   }
   const config = getAppConfig();
@@ -75,6 +80,6 @@ export const isRenewable: (currentApp: Application) => boolean = (currentApp) =>
     .endOf('day')
     .add(config.durations.expiry.daysPostExpiry, 'days');
 
-  // between DAYS_TO_EXPIRY_1 days prior to today and DAYS_POST_EXPIRY after
+  // can only renew if the expiry falls between DAYS_TO_EXPIRY_1 days prior to today and DAYS_POST_EXPIRY after
   return now.isBetween(expiryPeriodStart, expiryPeriodEnd);
 };


### PR DESCRIPTION
Adds new `POST` endpoint for creating a renewal
- adds `renewalAppId` to source application and `sourceAppId` to renewal app, for tracking. Adds these to search values
- adds `renewalPeriodEndDateUtc` to track when a renewal app should be closed, if it has been approved or submitted for review
- uses mongoose `withTransaction` to allow rollback of a created renewal if any of the db ops fails
- updates docker-compose mongo setup to use replicaSet to allow mongoose transactions in local development
- renewal apps will copy over ethics docs object ids, so check added to any delete actions to prevent file deletion if the objectId is referenced in another application
- updates swagger
- adds `PAUSED` state to allowed states fore `isRenewable`
- handling for renewals that are closed before approval will be implemented in #370 