### PR TITLE
🐛 392 - add missing state cases to onStateChange call. Add 400 error name

### DIFF
--- a/src/domain/service/applications/index.ts
+++ b/src/domain/service/applications/index.ts
@@ -272,7 +272,8 @@ export async function onStateChange(
 
     case 'DRAFT':
     case 'SIGN AND SUBMIT':
-      // this scenario occurs when an application transitions between DRAFT and SIGN AND SUBMIT, due to sections becoming complete/incomplete while editing
+      // this scenario occurs when the application transitions from DRAFT to SIGN AND SUBMIT, due to sections becoming complete while editing
+      // OR when an application transitions back to DRAFT from SIGN AND SUBMIT, due to a section becoming incomplete again
       // no emails are sent in this scenario, but need to account for this to prevent throwing error in default case, which breaks validation in the UI
       break;
 

--- a/src/domain/service/applications/index.ts
+++ b/src/domain/service/applications/index.ts
@@ -270,6 +270,12 @@ export async function onStateChange(
       await sendAccessHasExpiredEmail(updatedApp, config, emailClient);
       break;
 
+    case 'DRAFT':
+    case 'SIGN AND SUBMIT':
+      // this scenario occurs when an application transitions between DRAFT and SIGN AND SUBMIT, due to sections becoming complete/incomplete while editing
+      // no emails are sent in this scenario, but need to account for this to prevent throwing error in default case, which breaks validation in the UI
+      break;
+
     default:
       throw new Error(`Invalid app state: ${updatedApp.state}`);
   }

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -1133,7 +1133,7 @@ function updateAppStateForSignAndSubmit(
   }
 
   if (!updatePart.sections) {
-    throw new Error();
+    throw new BadRequest('Invalid request body for this application state.');
   }
 
   // applicant went back and updated completed sections (we treat that as an update in draft state)

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,7 @@
 export class BadRequest extends Error {
   constructor(public readonly info: any) {
     super(JSON.stringify(info));
+    this.name = 'Bad Request';
   }
 }
 


### PR DESCRIPTION
Fixes issue where the server would return a 500 error when an app transitioned between `DRAFT` and `SIGN AND SUBMIT`, because these cases were not included in the switch