### PR TITLE
fix isEthicsDocReferenced result usage

### DIFF
--- a/src/domain/service/applications/index.ts
+++ b/src/domain/service/applications/index.ts
@@ -113,6 +113,7 @@ async function unlinkRenewalFromSourceApp(
       await ApplicationModel.findOneAndUpdate({ appId: renewalApp.appId }, renewalApp, {
         session,
       });
+      // TODO: add a check that sourceAppId has been removed before proceeding: https://github.com/icgc-argo/dac-api/issues/395
       logger.info(`Fetching source application ${sourceAppId}.`);
       const query: FilterQuery<ApplicationDocument> = {
         appId: sourceAppId,
@@ -165,7 +166,12 @@ export async function updatePartial(
   }
   const stateManager = new ApplicationStateManager(appDocObj);
   const updatedApp = stateManager.updateApp(appPart, isReviewer, getUpdateAuthor(identity));
-  if (appDocObj.isRenewal && !renewalPeriodIsEnded(appDocObj) && isInPreSubmittedState(appDocObj)) {
+  if (
+    appDocObj.isRenewal &&
+    !renewalPeriodIsEnded(appDocObj) &&
+    isInPreSubmittedState(appDocObj) &&
+    appPart.state === 'CLOSED'
+  ) {
     logger.info('Closing an unsubmitted renewal');
     const sourceAppId = appDocObj.sourceAppId;
     if (sourceAppId) {
@@ -300,8 +306,8 @@ async function checkDeletedDocuments(originalApp: Application, updatedApp: Appli
   // we check that objectIds are unique, to ensure they are not deleted from object storage if associated with another application
   const uniqueEthicsIds: string[] = [];
   for await (const id of ethicsDiff) {
-    const isUnique = await !isEthicsDocReferenced(id);
-    if (isUnique) {
+    const isReferenced = await isEthicsDocReferenced(id);
+    if (!isReferenced) {
       uniqueEthicsIds.push(id);
     }
     break;

--- a/src/domain/service/files.ts
+++ b/src/domain/service/files.ts
@@ -65,7 +65,12 @@ export async function deleteDocument(
   await ApplicationModel.updateOne({ appId: result.appId }, result);
   // if doc type is ethics letter, check if the objectId is referenced in another application
   // if not referenced elsewhere, it is safe to delete from object storage
-  const shouldDeleteFile = type === 'ETHICS' ? await !isEthicsDocReferenced(objectId) : true;
+
+  let shouldDeleteFile = true;
+  if (type === 'ETHICS') {
+    const isReferenced = await isEthicsDocReferenced(objectId);
+    shouldDeleteFile = !isReferenced;
+  }
   if (shouldDeleteFile) {
     logger.info(`File with objectId [${objectId}] was unique, can delete from storage`);
     // delete the file from object storage


### PR DESCRIPTION
Fixes the incorrect negation on the isReferenced calls - promises are truthy so the result was always false! 🤦‍♀️ 
Also adds `CLOSED` update check to the close renewal logic - this flow should only occur when a renewal is being closed
* I created the ticket in the wrong repo, will update that