### PR TITLE
🐛 402 - trigger revisions email when requested on signature only

### DIFF
--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -901,6 +901,18 @@ function updateAppStateForReviewApplication(
   }
 }
 
+export function signatureOnlySectionRequiringRevisions(application: Application) {
+  const sectionsWithRevisions = Object.keys(application.revisionRequest)
+    .filter((sec) => sec !== 'general')
+    .filter(
+      (section) => application.revisionRequest[section as keyof RevisionRequestUpdate].requested,
+    );
+  const revisionsOnSignatureSectionOnly =
+    sectionsWithRevisions.length === 1 && sectionsWithRevisions[0] === 'signature';
+
+  return revisionsOnSignatureSectionOnly;
+}
+
 function transitionToRevisionsRequested(
   current: Application,
   updatePart: Partial<UpdateApplication>,
@@ -920,14 +932,10 @@ function transitionToRevisionsRequested(
   // empty the signature (need to delete the document too.)
   resetSignedDocument(current);
 
-  const sectionsWithRevisions = Object.keys(current.revisionRequest).filter(
-    (section) => current.revisionRequest[section as keyof RevisionRequestUpdate].requested,
-  );
-  const revisionsOnSignatureSectionOnly =
-    sectionsWithRevisions.length === 1 && sectionsWithRevisions[0] === 'signature';
-
   // put into SIGN AND SUBMIT state when just the signature section has revisions requested to allow user to upload a new signed doc
-  current.state = revisionsOnSignatureSectionOnly ? 'SIGN AND SUBMIT' : 'REVISIONS REQUESTED';
+  current.state = signatureOnlySectionRequiringRevisions(current)
+    ? 'SIGN AND SUBMIT'
+    : 'REVISIONS REQUESTED';
   current.updates.push(createUpdateEvent(current, updateAuthor, UpdateEvent.REVISIONS_REQUESTED));
   return current;
 }

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -54,6 +54,7 @@ import {
   DacoRole,
   PauseReason,
   NotificationSentFlags,
+  RevisionSections,
 } from './interface';
 import {
   validateAppendices,
@@ -902,11 +903,13 @@ function updateAppStateForReviewApplication(
 }
 
 export function signatureOnlySectionRequiringRevisions(application: Application) {
-  const sectionsWithRevisions = Object.keys(application.revisionRequest)
+  const revisionRequestKeys = Object.keys(application.revisionRequest);
+  const isRevisionType = (k: any): k is RevisionSections => revisionRequestKeys.includes(k);
+
+  const sectionsWithRevisions = revisionRequestKeys
+    .filter(isRevisionType)
     .filter((sec) => sec !== 'general')
-    .filter(
-      (section) => application.revisionRequest[section as keyof RevisionRequestUpdate].requested,
-    );
+    .filter((section) => application.revisionRequest[section].requested);
   const revisionsOnSignatureSectionOnly =
     sectionsWithRevisions.length === 1 && sectionsWithRevisions[0] === 'signature';
 


### PR DESCRIPTION
Triggers revisions email when the only section that requires a revision is signature, because in this scenario the app state is `SIGN AND SUBMIT`, not `REVISIONS REQUESTED`