### PR TITLE
🐛 395 - Verify renewal and source app ids are removed on unlink call

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -49,9 +49,9 @@ logger.info('in server.ts');
   try {
     connection = await database.connect();
     const migrated = await up(connection.db);
-    migrated.forEach((fileName: string) => logger.info('Migrated:', fileName));
+    migrated.forEach((fileName: string) => logger.info(`Migrated: ${fileName}`));
   } catch (err) {
-    logger.error('failed to do migration', err);
+    logger.error(`Failed to do migration: ${err}`);
     process.exit(-10);
     return;
   }


### PR DESCRIPTION
Add checks for null `renewalAppId` and `sourceAppId` when unlinking a unsubmitted renewal from its source application. Transaction will roll back.
- fixes incorrect syntax in migration logger statements