### PR TITLE
🐛 414 - fix ethics doc reference iteration

### DIFF
--- a/src/domain/service/applications/index.ts
+++ b/src/domain/service/applications/index.ts
@@ -347,7 +347,6 @@ async function checkDeletedDocuments(originalApp: Application, updatedApp: Appli
     if (!isReferenced) {
       uniqueEthicsIds.push(id);
     }
-    break;
   }
   uniqueEthicsIds.forEach((o) => removedIds.push(o));
 


### PR DESCRIPTION
`break` was _breaking_ the intended `for...await` functionality
(stopped the loop from iterating over multiple items in the array, whoops)