### PR TITLE
✨ 419 - add renewal period end date as calculated field for FE

### DIFF
--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -175,6 +175,7 @@ interface ApplicationBaseFields {
   renewalAppId?: string | null;
   renewalPeriodEndDateUtc?: Date;
   expiredEventDateUtc?: Date;
+  sourceRenewalPeriodEndDateUtc?: Date; // calculated
 }
 
 export interface ApplicationSummary extends ApplicationBaseFields {

--- a/src/domain/service/applications/search.ts
+++ b/src/domain/service/applications/search.ts
@@ -32,7 +32,12 @@ import {
   UserDataFromApprovedApplicationsResult,
 } from '../../interface';
 
-import { getAttestationByDate, isAttestable, isRenewable } from '../../../utils/calculations';
+import {
+  getAttestationByDate,
+  getRenewalPeriodEndDate,
+  isAttestable,
+  isRenewable,
+} from '../../../utils/calculations';
 import { checkIsDefined, getExpiredEventDate, getLastPausedAtDate } from '../../../utils/misc';
 import { hasReviewScope } from '../../../utils/permissions';
 
@@ -195,6 +200,9 @@ export async function search(params: SearchParams, identity: Identity): Promise<
         renewalAppId: app.renewalAppId,
         renewalPeriodEndDateUtc: app.renewalPeriodEndDateUtc,
         expiredEventDateUtc: getExpiredEventDate(app),
+        sourceRenewalPeriodEndDateUtc: app.expiresAtUtc
+          ? getRenewalPeriodEndDate(app.expiresAtUtc)
+          : undefined,
       } as ApplicationSummary),
   );
 

--- a/src/domain/state.ts
+++ b/src/domain/state.ts
@@ -75,6 +75,7 @@ import {
   isExpirable,
   isRenewable,
   isInPreSubmittedState,
+  getRenewalPeriodEndDate,
 } from '../utils/calculations';
 import { getExpiredEventDate, getLastPausedAtDate, mergeKnown } from '../utils/misc';
 import {
@@ -217,6 +218,9 @@ export class ApplicationStateManager {
     // adding to response for convenience in FE, so it doesn't need to parse value from updates array
     this.currentApplication.lastPausedAtUtc = getLastPausedAtDate(this.currentApplication);
     this.currentApplication.expiredEventDateUtc = getExpiredEventDate(this.currentApplication);
+    this.currentApplication.sourceRenewalPeriodEndDateUtc = this.currentApplication.expiresAtUtc
+      ? getRenewalPeriodEndDate(this.currentApplication.expiresAtUtc)
+      : undefined;
 
     return this.currentApplication;
   }
@@ -635,16 +639,6 @@ export function getSearchFieldValues(appDoc: Application) {
 
 function getPristineMeta(): Meta {
   return { status: 'PRISTINE', errorsList: [] };
-}
-
-export function getRenewalPeriodEndDate(expiry: Date): Date {
-  const {
-    durations: {
-      expiry: { daysPostExpiry },
-    },
-  } = getAppConfig();
-  const endDate = moment.utc(expiry).add(daysPostExpiry, NOTIFICATION_UNIT_OF_TIME).endOf('day');
-  return endDate.toDate();
 }
 
 export function renewalApplication(


### PR DESCRIPTION
Adds `sourceRenewalPeriodEndDateUtc` as a calculated field for the FE to use, to keep renewal period consistent.
- FE no longer needs to track a `DAYS_POST_EXPIRY` env var (https://github.com/icgc-argo/dac-ui/pull/686)
