### PR TITLE
🎨 428 - use dates instead of 'days until' for warning emails.

### DIFF
--- a/src/domain/service/emails.ts
+++ b/src/domain/service/emails.ts
@@ -378,20 +378,13 @@ export async function sendAttestationReceivedEmail(
 export async function sendAccessExpiringEmail(
   updatedApp: Application,
   config: AppConfig,
-  daysToExpiry: number, // this will come from the cronjob that is executing, i.e. first (90 days) or second (45 days) warning
   emailClient: nodemail.Transporter<SMTPTransport.SentMessageInfo>,
 ) {
-  const title = `Your Access is Expiring in ${daysToExpiry} days`;
-  const notificationEmail = await renderAccessExpiringEmail(
-    updatedApp,
-    config.email.links,
-    {
-      baseUrl: config.ui.baseUrl,
-      pathTemplate: config.ui.sectionPath,
-    },
-    config.durations,
-    daysToExpiry,
-  );
+  const title = `Your Access is Expiring Soon`;
+  const notificationEmail = await renderAccessExpiringEmail(updatedApp, config.email.links, {
+    baseUrl: config.ui.baseUrl,
+    pathTemplate: config.ui.sectionPath,
+  });
   const emailContent = notificationEmail.html;
   const subject = `[${updatedApp.appId}] ${title}`;
 
@@ -411,15 +404,10 @@ export async function sendAccessHasExpiredEmail(
   emailClient: nodemail.Transporter<SMTPTransport.SentMessageInfo>,
 ) {
   const title = `Your Access to ICGC Controlled Data has Expired`;
-  const notificationEmail = await renderAccessHasExpiredEmail(
-    updatedApp,
-    config.email.links,
-    {
-      baseUrl: config.ui.baseUrl,
-      pathTemplate: config.ui.sectionPath,
-    },
-    config.durations,
-  );
+  const notificationEmail = await renderAccessHasExpiredEmail(updatedApp, config.email.links, {
+    baseUrl: config.ui.baseUrl,
+    pathTemplate: config.ui.sectionPath,
+  });
   const emailContent = notificationEmail.html;
   const subject = `[${updatedApp.appId}] ${title}`;
 

--- a/src/emails/access-expiring.ts
+++ b/src/emails/access-expiring.ts
@@ -7,20 +7,21 @@ import {
   compose,
   textParagraphSection,
   UILinksInfo,
+  TEXT_DISPLAY_DATE,
+  formatDate,
 } from './common';
 import { compileMjmlInPromise } from './mjml';
+import { getRenewalPeriodEndDate } from '../utils/calculations';
 
 export default async function (
   app: Application,
   linksConfigs: AppConfig['email']['links'],
   uiLinksInfo: UILinksInfo,
-  durationConfigs: AppConfig['durations'],
-  daysToExpiry: number,
 ) {
   const info = app.sections.applicant.info;
   const emailMjml = compose(
     {
-      message: messageBody(app, uiLinksInfo, durationConfigs, daysToExpiry),
+      message: messageBody(app, uiLinksInfo),
       receiver: {
         first: info.firstName,
         last: info.lastName,
@@ -32,29 +33,35 @@ export default async function (
         guideText: 'Help Guides for Access Renewal',
       },
     },
-    `Your Access is Expiring in ${daysToExpiry} days`,
+    `Your Access is Expiring Soon`,
   );
 
   const htmlOutput = await compileMjmlInPromise(emailMjml);
   if (htmlOutput.errors.length > 0) {
     console.error(`template errors ${JSON.stringify(htmlOutput.errors)}`);
-    throw new Error('failed to generate email');
+    throw new Error('Failed to generate email');
   }
   return { html: htmlOutput.html, emailMjml };
 }
 
-function messageBody(
-  app: Application,
-  uiLinksInfo: UILinksInfo,
-  durationConfigs: AppConfig['durations'],
-  daysToExpiry: number,
-) {
+function messageBody(app: Application, uiLinksInfo: UILinksInfo) {
   const linkTemplate = `${uiLinksInfo.baseUrl}${uiLinksInfo.pathTemplate}`;
   const link = linkTemplate.replace(`{id}`, app.appId).replace('{section}', 'terms');
-  const daysLeftForRenewal = daysToExpiry + durationConfigs.expiry.daysPostExpiry;
+  const renewalPeriodEndDate = getRenewalPeriodEndDate(app.expiresAtUtc);
+
   return `
     ${textParagraphSection(
-      `<strong>The following application is expiring in ${daysToExpiry} days.</strong> On the date of expiry, all project members will lose access to ICGC Controlled Data.`,
+      `<strong>The following application is expiring on ${formatDate(
+        app.expiresAtUtc,
+        TEXT_DISPLAY_DATE,
+      )}.</strong> On the date of expiry, all project members will lose access to ICGC Controlled Data.`,
+      { padding: '0px 0px 20px 0px' },
+    )}
+    ${textParagraphSection(
+      `You have <strong>until ${formatDate(
+        renewalPeriodEndDate,
+        TEXT_DISPLAY_DATE,
+      )} to complete a renewal</strong> to extend your project team's access privileges for another two years.`,
       { padding: '0px 0px 20px 0px' },
     )}
     ${appInfoBox(app, 'Approved on', app.approvedAtUtc, false)}
@@ -64,11 +71,7 @@ function messageBody(
       'The following are your access details:',
     )}
     ${textParagraphSection(
-      `You have <strong>${daysLeftForRenewal} days to renew</strong> your project team’s access privileges for another two years.`,
-      { padding: '0px 0px 20px 0px' },
-    )}
-    ${textParagraphSection(
-      `Once you begin the renewal process, the application will be unlocked for edits. You will be required to review and agree to all Data Access policies again before signing and resubmitting.`,
+      `If you have not already initiated the renewal process, you can do so from your DACO application.  You will be required to review and agree to all Data Access policies again before signing and resubmitting.`,
       { padding: '0px 0px 20px 0px' },
     )}
     ${actionGetStarted(`Get Started:`, `RENEW YOUR ACCESS`, link)}

--- a/src/emails/attestation-required.ts
+++ b/src/emails/attestation-required.ts
@@ -8,6 +8,7 @@ import {
   UILinksInfo,
   approvalDetailsContent,
   formatDate,
+  TEXT_DISPLAY_DATE,
 } from './common';
 import { compileMjmlInPromise } from './mjml';
 import { getAttestationByDate } from '../utils/calculations';
@@ -16,7 +17,7 @@ export default async function (app: Application, uiLinksInfo: UILinksInfo, confi
   const info = app.sections.applicant.info;
   const emailMjml = compose(
     {
-      message: messageBody(app, uiLinksInfo, config),
+      message: messageBody(app, uiLinksInfo),
       receiver: {
         first: info.firstName,
         last: info.lastName,
@@ -39,7 +40,7 @@ export default async function (app: Application, uiLinksInfo: UILinksInfo, confi
   return { html: htmlOutput.html, emailMjml };
 }
 
-function messageBody(app: Application, uiLinksInfo: UILinksInfo, config: AppConfig) {
+function messageBody(app: Application, uiLinksInfo: UILinksInfo) {
   const linkTemplate = `${uiLinksInfo.baseUrl}${uiLinksInfo.pathTemplate}`;
   const link = linkTemplate.replace(`{id}`, app.appId).replace('{section}', 'terms');
   const attestationData = [
@@ -73,7 +74,10 @@ function messageBody(app: Application, uiLinksInfo: UILinksInfo, config: AppConf
     ${appInfoBox(app, 'Approved on', app.approvedAtUtc, false)}
     ${approvalDetailsContent(attestationData, 'Project access and attestation details:', 170)}
     ${textParagraphSection(
-      `You have <strong>${config.durations.attestation.daysToAttestation} days to log in and complete an attestation for this project</strong>. If you do not complete the attestation by the due date noted above, access to ICGC Controlled Data will be paused for your project team.`,
+      `You have <strong>until ${formatDate(
+        getAttestationByDate(app.approvedAtUtc),
+        TEXT_DISPLAY_DATE,
+      )} to log in and complete an attestation for this project</strong>. If you do not complete the attestation by the due date noted above, access to ICGC Controlled Data will be paused for your project team.`,
       { padding: '0px 0px 20px 0px' },
     )}
     ${actionGetStarted(`Get Started:`, `COMPLETE ATTESTATION`, link)}

--- a/src/emails/common.ts
+++ b/src/emails/common.ts
@@ -22,6 +22,9 @@ export const defaultTextStyle = {
   padding: '0',
 };
 
+const FULL_DISPLAY_DATE = 'MMM D, YYYY [at] LT';
+export const TEXT_DISPLAY_DATE = 'MMM D, YYYY';
+
 export function compose(cardData: ComposeArgs, subject: string) {
   return `
     <mjml>
@@ -222,8 +225,8 @@ export function appInfoBox(
   );
 }
 
-export function formatDate(d: Date) {
-  return moment(d).utc().format('MMM D, YYYY [at] LT');
+export function formatDate(d: Date, format: string = FULL_DISPLAY_DATE) {
+  return moment(d).utc().format(format);
 }
 
 export function getApplicantName(info: PersonalInfo) {
@@ -344,6 +347,7 @@ export const approvalDetailsContent = (
       </mj-column>
     </mj-section>`;
 };
+
 function closure(props: { guideLink: string; guideText: string }) {
   const { guideLink, guideText } = props;
   return `

--- a/src/jobs/firstExpiryNotification.ts
+++ b/src/jobs/firstExpiryNotification.ts
@@ -79,13 +79,8 @@ const sendNotification = async (
   emailClient: Transporter<SMTPTransport.SentMessageInfo>,
   config: AppConfig,
 ): Promise<JobResultForApplication> => {
-  const {
-    durations: {
-      expiry: { daysToExpiry1 },
-    },
-  } = config;
   try {
-    await sendAccessExpiringEmail(app, config, daysToExpiry1, emailClient);
+    await sendAccessExpiringEmail(app, config, emailClient);
     const updatedApp = await setEmailSentFlag(app, 'firstExpiryNotificationSent', JOB_NAME);
     return { success: true, app: updatedApp };
   } catch (err: unknown) {

--- a/src/jobs/secondExpiryNotification.ts
+++ b/src/jobs/secondExpiryNotification.ts
@@ -80,13 +80,8 @@ const sendNotification = async (
   emailClient: Transporter<SMTPTransport.SentMessageInfo>,
   config: AppConfig,
 ): Promise<JobResultForApplication> => {
-  const {
-    durations: {
-      expiry: { daysToExpiry2 },
-    },
-  } = config;
   try {
-    await sendAccessExpiringEmail(app, config, daysToExpiry2, emailClient);
+    await sendAccessExpiringEmail(app, config, emailClient);
     const updatedApp = await setEmailSentFlag(app, 'secondExpiryNotificationSent', JOB_NAME);
     return { success: true, app: updatedApp };
   } catch (err: unknown) {

--- a/src/test/emails.spec.ts
+++ b/src/test/emails.spec.ts
@@ -131,36 +131,14 @@ describe('emails', () => {
       const email = await rejected(app, emailLinksStub);
     });
 
-    it('should render an access expiring in 45 days email', async () => {
+    it('should render an access expiring email', async () => {
       const app = getApprovedApplication();
-      const email = await renderAccessExpiringEmail(
-        app,
-        emailLinksStub,
-        uiLinksStub,
-        durationsStub,
-        emailTestConfig.durations.expiry.daysToExpiry2,
-      );
-    });
-
-    it('should render an access expiring in 90 days email', async () => {
-      const app = getApprovedApplication();
-      const email = await renderAccessExpiringEmail(
-        app,
-        emailLinksStub,
-        uiLinksStub,
-        durationsStub,
-        emailTestConfig.durations.expiry.daysToExpiry1,
-      );
+      const email = await renderAccessExpiringEmail(app, emailLinksStub, uiLinksStub);
     });
 
     it('should render an access has expired email', async () => {
       const app = getApprovedApplication();
-      const email = await renderAccessHasExpiredEmail(
-        app,
-        emailLinksStub,
-        uiLinksStub,
-        durationsStub,
-      );
+      const email = await renderAccessHasExpiredEmail(app, emailLinksStub, uiLinksStub);
     });
 
     it('should render an attestation required email', async () => {


### PR DESCRIPTION
Change expiry and attestation emails to use dates instead of countdown values, for clarity.
- expiry emails will refer to `expiresAtUtc` and renewal period end date when giving renewal timeframes. Email title for pre-expiry warnings is made generic, and both the first and second expiry warnings will use the same email
- attestation warning will refer to `attestationByUtc` when giving attestation timeframes
- small refactor for `formatDate` helper used in emails, to allow for format string customization
- on collaborator removed email, specifies which date to use for `Access Removed on` value, depending on state
- updates expiry email language to reflect new renewal flow