### PR TITLE
🐛 437 - use expired event date in expired app email

### DIFF
--- a/src/emails/access-has-expired.ts
+++ b/src/emails/access-has-expired.ts
@@ -12,6 +12,7 @@ import {
   TEXT_DISPLAY_DATE,
 } from './common';
 import { compileMjmlInPromise } from './mjml';
+import { getExpiredEventDate } from '../utils/misc';
 
 export default async function (
   app: Application,
@@ -48,6 +49,8 @@ function messageBody(app: Application, uiLinksInfo: UILinksInfo, surveyUrl: stri
   const linkTemplate = `${uiLinksInfo.baseUrl}${uiLinksInfo.pathTemplate}`;
   const link = linkTemplate.replace(`{id}`, app.appId).replace('{section}', 'terms');
   const renewalPeriodEndDate = getRenewalPeriodEndDate(app.expiresAtUtc);
+  const expiryEventDate = getExpiredEventDate(app);
+
   const expiryData = [
     {
       label: 'Title of Project',
@@ -59,9 +62,10 @@ function messageBody(app: Application, uiLinksInfo: UILinksInfo, surveyUrl: stri
     },
     {
       label: 'Access Expired on',
-      value: formatDate(app.expiredEventDateUtc || app.expiresAtUtc),
+      value: formatDate(expiryEventDate || app.expiresAtUtc),
     },
   ];
+
   return `
     ${textParagraphSection(
       `Access to ICGC Controlled Data has expired for the following project team. Kindly note, it may take up to 24 hours for this status change to take effect.`,

--- a/src/test/emails.spec.ts
+++ b/src/test/emails.spec.ts
@@ -17,6 +17,7 @@ import {
   getAppInReview,
   getAppInRevisionRequested,
   getApprovedApplication,
+  getExpiredApplication,
   getPausedApplication,
   getRejectedApplication,
 } from './state.spec';
@@ -25,7 +26,6 @@ import { mockedConfig } from './mocks.spec';
 
 const emailTestConfig = mockedConfig();
 const emailLinksStub = emailTestConfig.email.links;
-const durationsStub = emailTestConfig.durations;
 const uiLinksStub = {
   baseUrl: emailTestConfig.ui.baseUrl,
   pathTemplate: emailTestConfig.ui.sectionPath,
@@ -137,7 +137,7 @@ describe('emails', () => {
     });
 
     it('should render an access has expired email', async () => {
-      const app = getApprovedApplication();
+      const app = getExpiredApplication();
       const email = await renderAccessHasExpiredEmail(app, emailLinksStub, uiLinksStub);
     });
 


### PR DESCRIPTION
Retrieve expiry event date from updates array; this field is calculated for the FE response so is not automatically available in the app object passed to the email generator