### PR TITLE
import fetch for node 16

### DIFF
--- a/src/jobs/ega/fetchPublicKey.ts
+++ b/src/jobs/ega/fetchPublicKey.ts
@@ -17,6 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import fetch from 'node-fetch';
 import urlJoin from 'url-join';
 import { AppConfig } from '../../config';
 


### PR DESCRIPTION
Dockerfile is using node:16, which doesn't include `fetch`. Need to import as `node-fetch` for the ega public key request.